### PR TITLE
Native multi-agent rendering

### DIFF
--- a/include/v4r.hpp
+++ b/include/v4r.hpp
@@ -19,18 +19,15 @@ public:
     std::shared_ptr<Mesh> loadMesh(std::string_view geometry_path);
 
     template <typename VertexType>
-    std::shared_ptr<Mesh> loadMesh(
-            std::vector<VertexType> vertices,
-            std::vector<uint32_t> indices);
+    std::shared_ptr<Mesh> loadMesh(std::vector<VertexType> vertices,
+                                   std::vector<uint32_t> indices);
 
     std::shared_ptr<Texture> loadTexture(std::string_view texture_path);
 
     template <typename MaterialParamsType>
-    std::shared_ptr<Material> makeMaterial(
-            MaterialParamsType params);
+    std::shared_ptr<Material> makeMaterial(MaterialParamsType params);
 
-    std::shared_ptr<Scene> makeScene(
-            const SceneDescription &desc);
+    std::shared_ptr<Scene> makeScene(const SceneDescription &desc);
 
     // Shortcut for Gibson style scene files
     std::shared_ptr<Scene> loadScene(std::string_view scene_path);
@@ -40,21 +37,29 @@ private:
 
     Handle<LoaderState> state_;
 
-friend class BatchRenderer;
+    friend class BatchRenderer;
 };
 
 class CommandStream {
 public:
     Environment makeEnvironment(const std::shared_ptr<Scene> &scene,
-                                float hfov, float near = 0.001f,
-                                float far = 10000.f);
+                                float hfov,
+                                float near = 0.001f,
+                                float far = 10000.f,
+                                int num_cameras = 1);
     // Render batch
     uint32_t render(const std::vector<Environment> &elems);
 
     void waitForFrame(uint32_t frame_id = 0);
 
-    const uint8_t *getRGB(uint32_t frame_id = 0) const { return rgb_[frame_id]; }
-    const float *getDepth(uint32_t frame_id = 0) const { return depth_[frame_id]; }
+    const uint8_t *getRGB(uint32_t frame_id = 0) const
+    {
+        return rgb_[frame_id];
+    }
+    const float *getDepth(uint32_t frame_id = 0) const
+    {
+        return depth_[frame_id];
+    }
 
 protected:
     CommandStream(Handle<CommandStreamState> &&state,
@@ -71,7 +76,7 @@ private:
     std::array<uint8_t *, 2> rgb_;
     std::array<float *, 2> depth_;
 
-friend class BatchRenderer;
+    friend class BatchRenderer;
 };
 
 class BatchRenderer {

--- a/include/v4r/environment.hpp
+++ b/include/v4r/environment.hpp
@@ -13,18 +13,20 @@ namespace v4r {
 class Environment {
 public:
     Environment(Environment &&) = default;
-    Environment & operator=(Environment &&) = default;
+    Environment &operator=(Environment &&) = default;
 
     // Instance transformations
-    inline uint32_t addInstance(uint32_t model_idx, uint32_t material_idx,
+    inline uint32_t addInstance(uint32_t model_idx,
+                                uint32_t material_idx,
                                 const glm::mat4 &model_matrix);
 
-    uint32_t addInstance(uint32_t model_idx, uint32_t material_idx,
+    uint32_t addInstance(uint32_t model_idx,
+                         uint32_t material_idx,
                          const glm::mat4x3 &model_matrix);
 
     void deleteInstance(uint32_t inst_id);
 
-    inline const glm::mat4x3 & getInstanceTransform(uint32_t inst_id) const;
+    inline const glm::mat4x3 &getInstanceTransform(uint32_t inst_id) const;
 
     inline void updateInstanceTransform(uint32_t inst_id,
                                         const glm::mat4 &model_matrix);
@@ -34,17 +36,25 @@ public:
 
     inline void setInstanceMaterial(uint32_t inst_id, uint32_t material_idx);
 
-    // Camera transformations
-    inline const glm::mat4 &getCameraView() const;
+    inline uint32_t addCamera(const glm::mat4 &mat);
 
-    inline void setCameraView(const glm::vec3 &eye, const glm::vec3 &look,
+    inline void setCameraActive(uint32_t camera_idx, uint8_t is_active);
+
+    // Camera transformations
+    inline const glm::mat4 &getCameraView(uint32_t camera_idx) const;
+
+    inline void setCameraView(uint32_t camera_idx,
+                              const glm::vec3 &eye,
+                              const glm::vec3 &look,
                               const glm::vec3 &up);
 
-    inline void setCameraView(const glm::mat4 &mat);
+    inline void setCameraView(uint32_t camera_idx, const glm::mat4 &mat);
 
-    inline void rotateCamera(float angle, const glm::vec3 &axis);
+    inline void rotateCamera(uint32_t camera_idx,
+                             float angle,
+                             const glm::vec3 &axis);
 
-    inline void translateCamera(const glm::vec3 &v);
+    inline void translateCamera(uint32_t camera_idx, const glm::vec3 &v);
 
     uint32_t addLight(const glm::vec3 &position, const glm::vec3 &color);
     void deleteLight(uint32_t light_id);
@@ -53,13 +63,14 @@ private:
     Environment(Handle<EnvironmentState> &&env);
 
     Handle<EnvironmentState> state_;
-    glm::mat4 view_;
+    std::vector<glm::mat4> views_;
+    std::vector<uint8_t> actives_;
     std::vector<std::pair<uint32_t, uint32_t>> index_map_;
     std::vector<std::vector<glm::mat4x3>> transforms_;
     std::vector<std::vector<uint32_t>> materials_;
 
-friend class CommandStream;
-friend class CommandStreamState;
+    friend class CommandStream;
+    friend class CommandStreamState;
 };
 
 }

--- a/include/v4r/environment.inl
+++ b/include/v4r/environment.inl
@@ -1,71 +1,88 @@
 #ifndef V4R_ENVIRONMENT_INL_INCLUDED
 #define V4R_ENVIRONMENT_INL_INCLUDED
 
+#include <iostream>
+
 #include <v4r/environment.hpp>
 
 #include <glm/gtc/matrix_transform.hpp>
 
 namespace v4r {
 
-uint32_t Environment::addInstance(uint32_t model_idx, uint32_t material_idx,
-                                  const glm::mat4x4 &matrix)
+uint32_t Environment::addInstance(uint32_t model_idx,
+                                  uint32_t material_idx,
+                                  const glm::mat4x4& matrix)
 {
     return addInstance(model_idx, material_idx, glm::mat4x3(matrix));
 }
 
-const glm::mat4x3 & Environment::getInstanceTransform(uint32_t inst_id) const
+const glm::mat4x3& Environment::getInstanceTransform(uint32_t inst_id) const
 {
-
-    const auto &p = index_map_[inst_id];
+    const auto& p = index_map_[inst_id];
     return transforms_[p.first][p.second];
 }
 
 void Environment::updateInstanceTransform(uint32_t inst_id,
-                                          const glm::mat4x3 &mat)
+                                          const glm::mat4x3& mat)
 {
-    const auto &p = index_map_[inst_id];
+    const auto& p = index_map_[inst_id];
     transforms_[p.first][p.second] = mat;
 }
 
 void Environment::updateInstanceTransform(uint32_t inst_id,
-                                          const glm::mat4 &mat)
+                                          const glm::mat4& mat)
 {
     updateInstanceTransform(inst_id, glm::mat4x3(mat));
 }
 
-void Environment::setInstanceMaterial(uint32_t inst_id,
-                                      uint32_t material_idx)
+void Environment::setInstanceMaterial(uint32_t inst_id, uint32_t material_idx)
 {
-    const auto &p = index_map_[inst_id];
+    const auto& p = index_map_[inst_id];
     materials_[p.first][p.second] = material_idx;
 }
 
-void Environment::setCameraView(const glm::vec3 &eye, const glm::vec3 &look,
-                                const glm::vec3 &up)
+uint32_t Environment::addCamera(const glm::mat4& mat)
 {
-    setCameraView(glm::lookAt(eye, look, up));
+    views_.emplace_back(mat);
+    actives_.emplace_back(1);
+    return views_.size() - 1;
 }
 
-const glm::mat4 &Environment::getCameraView() const
+void Environment::setCameraActive(uint32_t camera_idx, uint8_t is_active)
 {
-    return view_;
+    actives_[camera_idx] = is_active;
 }
 
-void Environment::setCameraView(const glm::mat4 &m)
+void Environment::setCameraView(uint32_t camera_idx,
+                                const glm::vec3& eye,
+                                const glm::vec3& look,
+                                const glm::vec3& up)
 {
-    view_ = m;
+    setCameraView(camera_idx, glm::lookAt(eye, look, up));
 }
 
-void Environment::rotateCamera(float angle, const glm::vec3 &axis)
+const glm::mat4& Environment::getCameraView(uint32_t camera_idx) const
 {
-    view_ = glm::rotate(view_, angle, axis);
+    return views_[camera_idx];
 }
 
-void Environment::translateCamera(const glm::vec3 &v)
+void Environment::setCameraView(uint32_t camera_idx, const glm::mat4& m)
 {
-    view_ = glm::translate(view_, v);
+    views_[camera_idx] = m;
 }
 
+void Environment::rotateCamera(uint32_t camera_idx,
+                               float angle,
+                               const glm::vec3& axis)
+{
+    views_[camera_idx] = glm::rotate(views_[camera_idx], angle, axis);
 }
+
+void Environment::translateCamera(uint32_t camera_idx, const glm::vec3& v)
+{
+    views_[camera_idx] = glm::translate(views_[camera_idx], v);
+}
+
+}  // namespace v4r
 
 #endif

--- a/src/pipelines/shaders/shader_common.h
+++ b/src/pipelines/shaders/shader_common.h
@@ -8,6 +8,8 @@ struct ViewInfo {
 
 struct RenderPushConstant {
     uint batchIdx;
+    uint lightsOffset;
+    uint numLights;
 };
 
 struct LightProperties {

--- a/src/pipelines/shaders/uber.frag
+++ b/src/pipelines/shaders/uber.frag
@@ -113,11 +113,11 @@ vec4 compute_color()
     vec3 finalDiffuseColor = vec3(0.73f) * diffuse.rgb;  // 0.33 for 0xbbbbbb_rgb diffuse color
     vec3 Lo = finalAmbientColor;
 
-    for (int light_idx = 0; light_idx < lighting_info.numLights; light_idx++) {
-        vec3 world_light_position = lighting_info.lights[light_idx].position.xyz;
+    for (int light_idx = 0; light_idx < render_const.numLights; light_idx++) {
+        vec3 world_light_position = lighting_info.lights[render_const.lightsOffset + light_idx].position.xyz;
         // vec3 light_position = (view_info[render_const.batchIdx].view * vec4(world_light_position, 1.f)).xyz;
         vec3 light_position = world_light_position;
-        vec3 light_color = lighting_info.lights[light_idx].color.xyz;
+        vec3 light_color = lighting_info.lights[render_const.lightsOffset + light_idx].color.xyz;
 
         #ifdef V4R_BLINN_PHONG
             BRDFParams brdf_params = makeBRDFParams(light_position, in_camera_pos,

--- a/src/shader.hpp
+++ b/src/shader.hpp
@@ -10,19 +10,19 @@ using namespace glm;
 using uint = uint32_t;
 
 #include "pipelines/shaders/shader_common.h"
-};
+};  // namespace Shader
 
-using Shader::ViewInfo;
 using Shader::RenderPushConstant;
+using Shader::ViewInfo;
 
 namespace VulkanConfig {
 
 constexpr uint32_t max_materials = MAX_MATERIALS;
 constexpr uint32_t max_lights = MAX_LIGHTS;
-constexpr uint32_t max_instances = 100000;
+constexpr uint32_t max_instances = 500000;
 
-}
+}  // namespace VulkanConfig
 
-}
+}  // namespace v4r
 
 #endif

--- a/src/vulkan_memory.cpp
+++ b/src/vulkan_memory.cpp
@@ -10,69 +10,65 @@ using namespace std;
 namespace v4r {
 
 namespace BufferFlags {
-    static constexpr VkBufferUsageFlags stageUsage =
-        VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
+static constexpr VkBufferUsageFlags stageUsage =
+    VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
 
-    static constexpr VkBufferUsageFlags shaderUsage =
-        VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT |
-        VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
+static constexpr VkBufferUsageFlags shaderUsage =
+    VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
 
-    static constexpr VkBufferUsageFlags hostGenericUsage =
-        VK_BUFFER_USAGE_VERTEX_BUFFER_BIT | shaderUsage;
+static constexpr VkBufferUsageFlags hostGenericUsage =
+    VK_BUFFER_USAGE_VERTEX_BUFFER_BIT | shaderUsage;
 
-    static constexpr VkBufferUsageFlags geometryUsage =
-        VK_BUFFER_USAGE_TRANSFER_DST_BIT |
-        VK_BUFFER_USAGE_VERTEX_BUFFER_BIT |
-        VK_BUFFER_USAGE_INDEX_BUFFER_BIT;
+static constexpr VkBufferUsageFlags hostResultsUsage =
+    VK_BUFFER_USAGE_TRANSFER_DST_BIT | hostGenericUsage;
 
-    static constexpr VkBufferUsageFlags localGenericUsage =
-        geometryUsage | shaderUsage;
+static constexpr VkBufferUsageFlags geometryUsage =
+    VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_VERTEX_BUFFER_BIT |
+    VK_BUFFER_USAGE_INDEX_BUFFER_BIT;
 
-    static constexpr VkBufferUsageFlags dedicatedUsage =
-        VK_BUFFER_USAGE_TRANSFER_SRC_BIT |
-        VK_BUFFER_USAGE_TRANSFER_DST_BIT;
+static constexpr VkBufferUsageFlags localGenericUsage =
+    geometryUsage | shaderUsage;
+
+static constexpr VkBufferUsageFlags dedicatedUsage =
+    VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT;
 };
 
 namespace ImageFlags {
-    static constexpr VkImageUsageFlags precomputedMipmapTextureUsage =
-        VK_IMAGE_USAGE_TRANSFER_DST_BIT |
-        VK_IMAGE_USAGE_SAMPLED_BIT;
+static constexpr VkImageUsageFlags precomputedMipmapTextureUsage =
+    VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
 
-    static constexpr VkImageUsageFlags runtimeMipmapTextureUsage =
-        VK_IMAGE_USAGE_TRANSFER_DST_BIT |
-        VK_IMAGE_USAGE_TRANSFER_SRC_BIT |
-        VK_IMAGE_USAGE_SAMPLED_BIT;
+static constexpr VkImageUsageFlags runtimeMipmapTextureUsage =
+    VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT |
+    VK_IMAGE_USAGE_SAMPLED_BIT;
 
-    static constexpr VkFormatFeatureFlags runtimeMipmapTextureReqs =
-        VK_FORMAT_FEATURE_BLIT_SRC_BIT |
-        VK_FORMAT_FEATURE_BLIT_DST_BIT |
-        VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT;
+static constexpr VkFormatFeatureFlags runtimeMipmapTextureReqs =
+    VK_FORMAT_FEATURE_BLIT_SRC_BIT | VK_FORMAT_FEATURE_BLIT_DST_BIT |
+    VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT;
 
-    static constexpr VkImageUsageFlags colorAttachmentUsage = 
-        VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT |
-        VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
+static constexpr VkImageUsageFlags colorAttachmentUsage =
+    VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
 
-    static constexpr VkFormatFeatureFlags colorAttachmentReqs =
-        VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT |
-        VK_FORMAT_FEATURE_TRANSFER_SRC_BIT;
+static constexpr VkFormatFeatureFlags colorAttachmentReqs =
+    VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT |
+    VK_FORMAT_FEATURE_TRANSFER_SRC_BIT;
 
-    static constexpr VkImageUsageFlags depthAttachmentUsage = 
-        VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT |
-        VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
+static constexpr VkImageUsageFlags depthAttachmentUsage =
+    VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT |
+    VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
 
-    static constexpr VkFormatFeatureFlags depthAttachmentReqs =
-        VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT |
-        VK_FORMAT_FEATURE_TRANSFER_SRC_BIT;
+static constexpr VkFormatFeatureFlags depthAttachmentReqs =
+    VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT |
+    VK_FORMAT_FEATURE_TRANSFER_SRC_BIT;
 };
 
-template<bool host_mapped>
+template <bool host_mapped>
 void AllocDeleter<host_mapped>::operator()(VkBuffer buffer) const
 {
     if (mem_ == VK_NULL_HANDLE) return;
 
     const DeviceState &dev = alloc_.dev;
 
-    if constexpr(host_mapped) {
+    if constexpr (host_mapped) {
         dev.dt.unmapMemory(dev.hdl, mem_);
     }
 
@@ -81,7 +77,7 @@ void AllocDeleter<host_mapped>::operator()(VkBuffer buffer) const
     dev.dt.destroyBuffer(dev.hdl, buffer, nullptr);
 }
 
-template<>
+template <>
 void AllocDeleter<false>::operator()(VkImage image) const
 {
     if (mem_ == VK_NULL_HANDLE) return;
@@ -92,16 +88,18 @@ void AllocDeleter<false>::operator()(VkImage image) const
     dev.dt.destroyImage(dev.hdl, image, nullptr);
 }
 
-template<bool host_mapped>
+template <bool host_mapped>
 void AllocDeleter<host_mapped>::clear()
 {
     mem_ = VK_NULL_HANDLE;
 }
 
-HostBuffer::HostBuffer(VkBuffer buf, void *p,
+HostBuffer::HostBuffer(VkBuffer buf,
+                       void *p,
                        VkMappedMemoryRange mem_range,
                        AllocDeleter<true> deleter)
-    : buffer(buf), ptr(p),
+    : buffer(buf),
+      ptr(p),
       mem_range_(mem_range),
       deleter_(deleter)
 {}
@@ -135,8 +133,7 @@ void HostBuffer::flush(const DeviceState &dev,
     dev.dt.flushMappedMemoryRanges(dev.hdl, 1, &sub_range);
 }
 
-LocalBuffer::LocalBuffer(VkBuffer buf,
-                         AllocDeleter<false> deleter)
+LocalBuffer::LocalBuffer(VkBuffer buf, AllocDeleter<false> deleter)
     : buffer(buf),
       deleter_(deleter)
 {}
@@ -153,15 +150,22 @@ LocalBuffer::~LocalBuffer()
     deleter_(buffer);
 }
 
-LocalImage::LocalImage(uint32_t w, uint32_t h, uint32_t mip_levels,
-                       VkImage img, AllocDeleter<false> deleter)
-    : width(w), height(h), mipLevels(mip_levels),
+LocalImage::LocalImage(uint32_t w,
+                       uint32_t h,
+                       uint32_t mip_levels,
+                       VkImage img,
+                       AllocDeleter<false> deleter)
+    : width(w),
+      height(h),
+      mipLevels(mip_levels),
       image(img),
       deleter_(deleter)
 {}
 
 LocalImage::LocalImage(LocalImage &&o)
-    : width(o.width), height(o.height), mipLevels(o.mipLevels),
+    : width(o.width),
+      height(o.height),
+      mipLevels(o.mipLevels),
       image(o.image),
       deleter_(o.deleter_)
 {
@@ -185,15 +189,16 @@ static VkFormatProperties2 getFormatProperties(const InstanceState &inst,
     return props;
 }
 
-template<size_t N>
-static VkFormat chooseFormat(VkPhysicalDevice phy, const InstanceState &inst,
+template <size_t N>
+static VkFormat chooseFormat(VkPhysicalDevice phy,
+                             const InstanceState &inst,
                              VkFormatFeatureFlags required_features,
                              const array<VkFormat, N> &desired_formats)
 {
     for (auto fmt : desired_formats) {
         VkFormatProperties2 props = getFormatProperties(inst, phy, fmt);
         if ((props.formatProperties.optimalTilingFeatures &
-                    required_features) == required_features) {
+             required_features) == required_features) {
             return fmt;
         }
     }
@@ -202,8 +207,10 @@ static VkFormat chooseFormat(VkPhysicalDevice phy, const InstanceState &inst,
     fatalExit();
 }
 
-pair<VkBuffer, VkMemoryRequirements> makeUnboundBuffer(const DeviceState &dev,
-        VkDeviceSize num_bytes, VkBufferUsageFlags usage)
+pair<VkBuffer, VkMemoryRequirements> makeUnboundBuffer(
+    const DeviceState &dev,
+    VkDeviceSize num_bytes,
+    VkBufferUsageFlags usage)
 {
     VkBufferCreateInfo buffer_info;
     buffer_info.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
@@ -223,8 +230,11 @@ pair<VkBuffer, VkMemoryRequirements> makeUnboundBuffer(const DeviceState &dev,
 }
 
 pair<VkImage, VkMemoryRequirements> makeUnboundImage(const DeviceState &dev,
-        uint32_t width, uint32_t height, uint32_t mip_levels,
-        VkFormat format, VkImageUsageFlags usage)
+                                                     uint32_t width,
+                                                     uint32_t height,
+                                                     uint32_t mip_levels,
+                                                     VkFormat format,
+                                                     VkImageUsageFlags usage)
 {
     VkImageCreateInfo img_info;
     img_info.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
@@ -232,7 +242,7 @@ pair<VkImage, VkMemoryRequirements> makeUnboundImage(const DeviceState &dev,
     img_info.flags = 0;
     img_info.imageType = VK_IMAGE_TYPE_2D;
     img_info.format = format;
-    img_info.extent = { width, height, 1 };
+    img_info.extent = {width, height, 1};
     img_info.mipLevels = mip_levels;
     img_info.arrayLayers = 1;
     img_info.samples = VK_SAMPLE_COUNT_1_BIT;
@@ -252,10 +262,9 @@ pair<VkImage, VkMemoryRequirements> makeUnboundImage(const DeviceState &dev,
     return pair(img, reqs);
 }
 
-
 uint32_t findMemoryTypeIndex(uint32_t allowed_type_bits,
-        VkMemoryPropertyFlags required_props,
-        VkPhysicalDeviceMemoryProperties2 &mem_props)
+                             VkMemoryPropertyFlags required_props,
+                             VkPhysicalDeviceMemoryProperties2 &mem_props)
 {
     uint32_t num_mems = mem_props.memoryProperties.memoryTypeCount;
 
@@ -289,8 +298,8 @@ static VkMemoryRequirements getImageMemReqs(const DeviceState &dev,
                                             VkFormat format,
                                             VkImageUsageFlags usage_flags)
 {
-    auto [test_image, reqs] = makeUnboundImage(dev, 1, 1, 1, format,
-                                               usage_flags);
+    auto [test_image, reqs] =
+        makeUnboundImage(dev, 1, 1, 1, format, usage_flags);
 
     dev.dt.destroyImage(dev.hdl, test_image, nullptr);
 
@@ -302,106 +311,88 @@ static MemoryTypeIndices findTypeIndices(const DeviceState &dev,
                                          const ResourceFormats &formats)
 {
     VkPhysicalDeviceMemoryProperties2 dev_mem_props;
-    dev_mem_props.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_PROPERTIES_2;
+    dev_mem_props.sType =
+        VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_PROPERTIES_2;
     dev_mem_props.pNext = nullptr;
     inst.dt.getPhysicalDeviceMemoryProperties2(dev.phy, &dev_mem_props);
 
-    VkMemoryRequirements stage_reqs = 
+    VkMemoryRequirements stage_reqs =
         getBufferMemReqs(dev, BufferFlags::stageUsage);
 
     uint32_t stage_type_idx = findMemoryTypeIndex(
-            stage_reqs.memoryTypeBits,
-            VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT,
-            dev_mem_props);
+        stage_reqs.memoryTypeBits, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT,
+        dev_mem_props);
 
     VkMemoryRequirements shader_reqs =
         getBufferMemReqs(dev, BufferFlags::shaderUsage);
 
     uint32_t shader_type_idx = findMemoryTypeIndex(
-            shader_reqs.memoryTypeBits,
-            VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT,
-            dev_mem_props);
+        shader_reqs.memoryTypeBits, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT,
+        dev_mem_props);
 
     VkMemoryRequirements host_generic_reqs =
         getBufferMemReqs(dev, BufferFlags::hostGenericUsage);
 
-    uint32_t host_generic_type_idx = findMemoryTypeIndex(
-            host_generic_reqs.memoryTypeBits,
-            VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_CACHED_BIT,
-            dev_mem_props);
+    uint32_t host_generic_type_idx =
+        findMemoryTypeIndex(host_generic_reqs.memoryTypeBits,
+                            VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT |
+                                VK_MEMORY_PROPERTY_HOST_CACHED_BIT,
+                            dev_mem_props);
 
     VkMemoryRequirements geometry_reqs =
         getBufferMemReqs(dev, BufferFlags::geometryUsage);
 
     uint32_t geometry_type_idx = findMemoryTypeIndex(
-            geometry_reqs.memoryTypeBits,
-            VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
-            dev_mem_props);
+        geometry_reqs.memoryTypeBits, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
+        dev_mem_props);
 
     VkMemoryRequirements local_generic_reqs =
         getBufferMemReqs(dev, BufferFlags::localGenericUsage);
 
     uint32_t local_generic_type_idx = findMemoryTypeIndex(
-            local_generic_reqs.memoryTypeBits,
-            VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
-            dev_mem_props);
+        local_generic_reqs.memoryTypeBits, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
+        dev_mem_props);
 
     VkMemoryRequirements dedicated_reqs =
         getBufferMemReqs(dev, BufferFlags::dedicatedUsage);
 
     uint32_t dedicated_type_idx = findMemoryTypeIndex(
-            dedicated_reqs.memoryTypeBits,
-            VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
-            dev_mem_props);
+        dedicated_reqs.memoryTypeBits, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
+        dev_mem_props);
 
-    VkMemoryRequirements texture_precomp_mip_reqs =
-        getImageMemReqs(dev, formats.hdrTexture,
-                        ImageFlags::precomputedMipmapTextureUsage);
+    VkMemoryRequirements texture_precomp_mip_reqs = getImageMemReqs(
+        dev, formats.hdrTexture, ImageFlags::precomputedMipmapTextureUsage);
 
     uint32_t texture_precomp_idx = findMemoryTypeIndex(
-            texture_precomp_mip_reqs.memoryTypeBits,
-            VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
-            dev_mem_props);
+        texture_precomp_mip_reqs.memoryTypeBits,
+        VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, dev_mem_props);
 
-    VkMemoryRequirements texture_runtime_mip_reqs =
-        getImageMemReqs(dev, formats.sdrTexture,
-                        ImageFlags::runtimeMipmapTextureUsage);
+    VkMemoryRequirements texture_runtime_mip_reqs = getImageMemReqs(
+        dev, formats.sdrTexture, ImageFlags::runtimeMipmapTextureUsage);
 
     uint32_t texture_runtime_idx = findMemoryTypeIndex(
-            texture_runtime_mip_reqs.memoryTypeBits,
-            VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
-            dev_mem_props);
+        texture_runtime_mip_reqs.memoryTypeBits,
+        VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, dev_mem_props);
 
-    VkMemoryRequirements color_attachment_reqs =
-        getImageMemReqs(dev, formats.colorAttachment,
-                        ImageFlags::colorAttachmentUsage);
+    VkMemoryRequirements color_attachment_reqs = getImageMemReqs(
+        dev, formats.colorAttachment, ImageFlags::colorAttachmentUsage);
 
     uint32_t color_attachment_idx = findMemoryTypeIndex(
-            color_attachment_reqs.memoryTypeBits,
-            VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
-            dev_mem_props);
+        color_attachment_reqs.memoryTypeBits,
+        VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, dev_mem_props);
 
-    VkMemoryRequirements depth_attachment_reqs =
-        getImageMemReqs(dev, formats.depthAttachment,
-                        ImageFlags::depthAttachmentUsage);
+    VkMemoryRequirements depth_attachment_reqs = getImageMemReqs(
+        dev, formats.depthAttachment, ImageFlags::depthAttachmentUsage);
 
     uint32_t depth_attachment_idx = findMemoryTypeIndex(
-            depth_attachment_reqs.memoryTypeBits,
-            VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
-            dev_mem_props);
+        depth_attachment_reqs.memoryTypeBits,
+        VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, dev_mem_props);
 
-    return MemoryTypeIndices {
-        stage_type_idx,
-        shader_type_idx,
-        host_generic_type_idx,
-        geometry_type_idx,
-        local_generic_type_idx,
-        dedicated_type_idx,
-        texture_precomp_idx,
-        texture_runtime_idx,
-        color_attachment_idx,
-        depth_attachment_idx
-    };
+    return MemoryTypeIndices {stage_type_idx,         shader_type_idx,
+                              host_generic_type_idx,  geometry_type_idx,
+                              local_generic_type_idx, dedicated_type_idx,
+                              texture_precomp_idx,    texture_runtime_idx,
+                              color_attachment_idx,   depth_attachment_idx};
 }
 
 static Alignments getMemoryAlignments(const InstanceState &inst,
@@ -413,31 +404,33 @@ static Alignments getMemoryAlignments(const InstanceState &inst,
 
     return Alignments {
         props.properties.limits.minUniformBufferOffsetAlignment,
-        props.properties.limits.minStorageBufferOffsetAlignment
-    };
+        props.properties.limits.minStorageBufferOffsetAlignment};
 }
 
 MemoryAllocator::MemoryAllocator(const DeviceState &d,
                                  const InstanceState &inst)
     : dev(d),
-      formats_ {
-          chooseFormat(dev.phy, inst,
-                       ImageFlags::runtimeMipmapTextureReqs,
-                       array { VK_FORMAT_R8G8B8A8_UNORM }),
-          chooseFormat(dev.phy, inst,
-                       ImageFlags::runtimeMipmapTextureReqs,
-                       array { VK_FORMAT_R16G16B16A16_SFLOAT }),
-          chooseFormat(dev.phy, inst,
-                       ImageFlags::colorAttachmentReqs,
-                       array { VK_FORMAT_R8G8B8A8_UNORM }),
-          chooseFormat(dev.phy, inst,
-                       ImageFlags::depthAttachmentReqs,
-                       array { VK_FORMAT_D32_SFLOAT,
-                               VK_FORMAT_D32_SFLOAT_S8_UINT }),
-          chooseFormat(dev.phy, inst,
-                       ImageFlags::colorAttachmentReqs,
-                       array { VK_FORMAT_R32_SFLOAT })
-      },
+      formats_ {chooseFormat(dev.phy,
+                             inst,
+                             ImageFlags::runtimeMipmapTextureReqs,
+                             array {VK_FORMAT_R8G8B8A8_UNORM}),
+                chooseFormat(dev.phy,
+                             inst,
+                             ImageFlags::runtimeMipmapTextureReqs,
+                             array {VK_FORMAT_R16G16B16A16_SFLOAT}),
+                chooseFormat(dev.phy,
+                             inst,
+                             ImageFlags::colorAttachmentReqs,
+                             array {VK_FORMAT_R8G8B8A8_UNORM}),
+                chooseFormat(dev.phy,
+                             inst,
+                             ImageFlags::depthAttachmentReqs,
+                             array {VK_FORMAT_D32_SFLOAT,
+                                    VK_FORMAT_D32_SFLOAT_S8_UINT}),
+                chooseFormat(dev.phy,
+                             inst,
+                             ImageFlags::colorAttachmentReqs,
+                             array {VK_FORMAT_R32_SFLOAT})},
       type_indices_(findTypeIndices(dev, inst, formats_)),
       alignments_(getMemoryAlignments(inst, dev.phy))
 {}
@@ -464,14 +457,12 @@ HostBuffer MemoryAllocator::makeHostBuffer(VkDeviceSize num_bytes,
     VkMappedMemoryRange range;
     range.sType = VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE;
     range.pNext = nullptr;
-    range.memory = memory,
-    range.offset = 0;
+    range.memory = memory, range.offset = 0;
     range.size = VK_WHOLE_SIZE;
 
     return HostBuffer(buffer, mapped_ptr, range,
                       AllocDeleter<true>(memory, *this));
 }
-
 
 HostBuffer MemoryAllocator::makeStagingBuffer(VkDeviceSize num_bytes)
 {
@@ -481,7 +472,7 @@ HostBuffer MemoryAllocator::makeStagingBuffer(VkDeviceSize num_bytes)
 
 HostBuffer MemoryAllocator::makeShaderBuffer(VkDeviceSize num_bytes)
 {
-    return makeHostBuffer(num_bytes, BufferFlags::shaderUsage, 
+    return makeHostBuffer(num_bytes, BufferFlags::shaderUsage,
                           type_indices_.shaderBuffer);
 }
 
@@ -491,12 +482,17 @@ HostBuffer MemoryAllocator::makeHostBuffer(VkDeviceSize num_bytes)
                           type_indices_.hostGenericBuffer);
 }
 
+HostBuffer MemoryAllocator::makeResultsBuffer(VkDeviceSize num_bytes)
+{
+    return makeHostBuffer(num_bytes, BufferFlags::hostResultsUsage,
+                          type_indices_.hostGenericBuffer);
+}
+
 LocalBuffer MemoryAllocator::makeLocalBuffer(VkDeviceSize num_bytes,
                                              VkBufferUsageFlags usage,
                                              uint32_t mem_idx)
 {
-    auto [buffer, reqs] = makeUnboundBuffer(dev, num_bytes,
-                                            usage);
+    auto [buffer, reqs] = makeUnboundBuffer(dev, num_bytes, usage);
 
     VkMemoryAllocateInfo alloc;
     alloc.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
@@ -524,10 +520,10 @@ LocalBuffer MemoryAllocator::makeGeometryBuffer(VkDeviceSize num_bytes)
 }
 
 pair<LocalBuffer, VkDeviceMemory> MemoryAllocator::makeDedicatedBuffer(
-        VkDeviceSize num_bytes)
+    VkDeviceSize num_bytes)
 {
-    auto [buffer, reqs] = makeUnboundBuffer(dev, num_bytes,
-                                            BufferFlags::dedicatedUsage);
+    auto [buffer, reqs] =
+        makeUnboundBuffer(dev, num_bytes, BufferFlags::dedicatedUsage);
 
     VkMemoryDedicatedAllocateInfo dedicated;
     dedicated.sType = VK_STRUCTURE_TYPE_MEMORY_DEDICATED_ALLOCATE_INFO;
@@ -548,14 +544,15 @@ pair<LocalBuffer, VkDeviceMemory> MemoryAllocator::makeDedicatedBuffer(
                 memory);
 }
 
-LocalImage MemoryAllocator::makeTexture(uint32_t width, uint32_t height,
+LocalImage MemoryAllocator::makeTexture(uint32_t width,
+                                        uint32_t height,
                                         uint32_t mip_levels,
                                         bool precomputed_mipmaps)
 {
-    auto [texture_img, reqs] = makeUnboundImage(dev, width, height, mip_levels,
-            formats_.sdrTexture,
-            precomputed_mipmaps ? ImageFlags::precomputedMipmapTextureUsage :
-                ImageFlags::runtimeMipmapTextureUsage);
+    auto [texture_img, reqs] = makeUnboundImage(
+        dev, width, height, mip_levels, formats_.sdrTexture,
+        precomputed_mipmaps ? ImageFlags::precomputedMipmapTextureUsage :
+                              ImageFlags::runtimeMipmapTextureUsage);
 
     VkMemoryAllocateInfo alloc;
     alloc.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
@@ -571,20 +568,20 @@ LocalImage MemoryAllocator::makeTexture(uint32_t width, uint32_t height,
     REQ_VK(dev.dt.allocateMemory(dev.hdl, &alloc, nullptr, &memory));
     REQ_VK(dev.dt.bindImageMemory(dev.hdl, texture_img, memory, 0));
 
-    return LocalImage(width, height,
-                      mip_levels, texture_img,
+    return LocalImage(width, height, mip_levels, texture_img,
                       AllocDeleter<false>(memory, *this));
 }
 
-LocalImage MemoryAllocator::makeDedicatedImage(uint32_t width, uint32_t height,
+LocalImage MemoryAllocator::makeDedicatedImage(uint32_t width,
+                                               uint32_t height,
                                                uint32_t mip_levels,
                                                VkFormat format,
                                                VkImageUsageFlags usage,
                                                uint32_t type_idx)
 {
-    auto [img, reqs] = makeUnboundImage(dev, width, height, mip_levels,
-                                        format, usage);
-    
+    auto [img, reqs] =
+        makeUnboundImage(dev, width, height, mip_levels, format, usage);
+
     VkMemoryDedicatedAllocateInfo dedicated;
     dedicated.sType = VK_STRUCTURE_TYPE_MEMORY_DEDICATED_ALLOCATE_INFO;
     dedicated.pNext = nullptr;
@@ -634,13 +631,13 @@ static VkDeviceSize alignOffset(VkDeviceSize offset, VkDeviceSize alignment)
 }
 
 VkDeviceSize MemoryAllocator::alignUniformBufferOffset(
-        VkDeviceSize offset) const
+    VkDeviceSize offset) const
 {
     return alignOffset(offset, alignments_.uniformBuffer);
 }
 
 VkDeviceSize MemoryAllocator::alignStorageBufferOffset(
-        VkDeviceSize offset) const
+    VkDeviceSize offset) const
 {
     return alignOffset(offset, alignments_.storageBuffer);
 }

--- a/src/vulkan_memory.hpp
+++ b/src/vulkan_memory.hpp
@@ -9,11 +9,12 @@ namespace v4r {
 
 class MemoryAllocator;
 
-template<bool host_mapped>
+template <bool host_mapped>
 class AllocDeleter {
 public:
     AllocDeleter(VkDeviceMemory mem, MemoryAllocator &alloc)
-        : mem_(mem), alloc_(alloc)
+        : mem_(mem),
+          alloc_(alloc)
     {}
 
     void operator()(VkBuffer buffer) const;
@@ -34,13 +35,16 @@ public:
     ~HostBuffer();
 
     void flush(const DeviceState &dev);
-    void flush(const DeviceState &dev, VkDeviceSize offset,
+    void flush(const DeviceState &dev,
+               VkDeviceSize offset,
                VkDeviceSize num_bytes);
 
     VkBuffer buffer;
     void *ptr;
+
 private:
-    HostBuffer(VkBuffer buf, void *p,
+    HostBuffer(VkBuffer buf,
+               void *p,
                VkMappedMemoryRange mem_range,
                AllocDeleter<true> deleter);
 
@@ -57,6 +61,7 @@ public:
     ~LocalBuffer();
 
     VkBuffer buffer;
+
 private:
     LocalBuffer(VkBuffer buf, AllocDeleter<false> deleter);
 
@@ -74,9 +79,13 @@ public:
     uint32_t height;
     uint32_t mipLevels;
     VkImage image;
+
 private:
-    LocalImage(uint32_t width, uint32_t height, uint32_t mip_levels,
-               VkImage image, AllocDeleter<false> deleter);
+    LocalImage(uint32_t width,
+               uint32_t height,
+               uint32_t mip_levels,
+               VkImage image,
+               AllocDeleter<false> deleter);
 
     AllocDeleter<false> deleter_;
     friend class MemoryAllocator;
@@ -117,16 +126,18 @@ public:
     HostBuffer makeStagingBuffer(VkDeviceSize num_bytes);
     HostBuffer makeShaderBuffer(VkDeviceSize num_bytes);
     HostBuffer makeHostBuffer(VkDeviceSize num_bytes);
+    HostBuffer makeResultsBuffer(VkDeviceSize num_bytes);
 
     LocalBuffer makeGeometryBuffer(VkDeviceSize num_bytes);
     LocalBuffer makeLocalBuffer(VkDeviceSize num_bytes);
 
     std::pair<LocalBuffer, VkDeviceMemory> makeDedicatedBuffer(
-            VkDeviceSize num_bytes);
+        VkDeviceSize num_bytes);
 
-    LocalImage makeTexture(uint32_t width, uint32_t height,
+    LocalImage makeTexture(uint32_t width,
+                           uint32_t height,
                            uint32_t mip_levels,
-                           bool precomputed_mipmaps=false);
+                           bool precomputed_mipmaps = false);
 
     LocalImage makeColorAttachment(uint32_t width, uint32_t height);
     LocalImage makeDepthAttachment(uint32_t width, uint32_t height);
@@ -146,16 +157,20 @@ private:
                                 VkBufferUsageFlags usage,
                                 uint32_t mem_idx);
 
-    LocalImage makeDedicatedImage(uint32_t width, uint32_t height,
-                                  uint32_t mip_levels, VkFormat format,
-                                  VkImageUsageFlags usage, uint32_t type_idx);
+    LocalImage makeDedicatedImage(uint32_t width,
+                                  uint32_t height,
+                                  uint32_t mip_levels,
+                                  VkFormat format,
+                                  VkImageUsageFlags usage,
+                                  uint32_t type_idx);
 
     const DeviceState &dev;
     ResourceFormats formats_;
     MemoryTypeIndices type_indices_;
     Alignments alignments_;
 
-    template<bool> friend class AllocDeleter;
+    template <bool>
+    friend class AllocDeleter;
 };
 
 }

--- a/src/vulkan_state.cpp
+++ b/src/vulkan_state.cpp
@@ -6,8 +6,8 @@
 #include "vulkan_config.hpp"
 
 #include <cmath>
-#include <iostream>
 #include <fstream>
+#include <iostream>
 #include <optional>
 #include <tuple>
 #include <vector>
@@ -20,18 +20,18 @@ namespace v4r {
 
 template <typename PipelineType>
 FramebufferConfig PipelineImpl<PipelineType>::getFramebufferConfig(
-    uint32_t batch_size, uint32_t img_width, uint32_t img_height,
-    uint32_t num_streams, const RenderOptions &opts)
+    uint32_t batch_size,
+    uint32_t img_width,
+    uint32_t img_height,
+    uint32_t num_streams,
+    const RenderOptions& opts)
 {
     using Props = PipelineProps<PipelineType>;
     constexpr bool need_color_output = Props::needColorOutput;
     constexpr bool need_depth_output = Props::needDepthOutput;
-    const bool is_double_buffered =
-        opts & RenderOptions::DoubleBuffered;
+    const bool is_double_buffered = opts & RenderOptions::DoubleBuffered;
 
-    uint32_t num_frames_per_stream =
-        is_double_buffered ?
-            2 : 1;
+    uint32_t num_frames_per_stream = is_double_buffered ? 2 : 1;
 
     uint32_t batch_fb_images_wide = ceil(sqrt(batch_size));
     while (batch_size % batch_fb_images_wide != 0) {
@@ -44,36 +44,35 @@ FramebufferConfig PipelineImpl<PipelineType>::getFramebufferConfig(
     uint32_t frame_fb_width = img_width * batch_fb_images_wide;
     uint32_t frame_fb_height = img_height * batch_fb_images_tall;
 
-    uint32_t total_fb_width = frame_fb_width * num_streams *
-        num_frames_per_stream;
+    uint32_t total_fb_width =
+        frame_fb_width * num_streams * num_frames_per_stream;
     uint32_t total_fb_height = frame_fb_height;
-    
+
     vector<VkClearValue> clear_vals;
 
     uint64_t frame_color_bytes = 0;
     if constexpr (need_color_output) {
-        frame_color_bytes = 
+        frame_color_bytes =
             4 * sizeof(uint8_t) * frame_fb_width * frame_fb_height;
 
         VkClearValue clear_val;
-        clear_val.color = {{ 0.f, 0.f, 0.f, 1.f }};
+        clear_val.color = {{0.f, 0.f, 0.f, 1.f}};
 
         clear_vals.push_back(clear_val);
     }
 
     uint64_t frame_depth_bytes = 0;
     if constexpr (need_depth_output) {
-        frame_depth_bytes =
-            sizeof(float) * frame_fb_width * frame_fb_height;
+        frame_depth_bytes = sizeof(float) * frame_fb_width * frame_fb_height;
 
         VkClearValue clear_val;
-        clear_val.color = {{ 0.f, 0.f, 0.f, 0.f }};
+        clear_val.color = {{0.f, 0.f, 0.f, 0.f}};
 
         clear_vals.push_back(clear_val);
     }
 
     VkClearValue depth_clear_value;
-    depth_clear_value.depthStencil = { 1.f, 0 };
+    depth_clear_value.depthStencil = {1.f, 0};
 
     clear_vals.push_back(depth_clear_value);
 
@@ -96,12 +95,11 @@ FramebufferConfig PipelineImpl<PipelineType>::getFramebufferConfig(
         frame_linear_bytes * num_streams * num_frames_per_stream,
         need_color_output,
         need_depth_output,
-        move(clear_vals)
-    };
+        move(clear_vals)};
 }
 
-static VkRenderPass makeRenderPass(const DeviceState &dev,
-                                   const ResourceFormats &fmts,
+static VkRenderPass makeRenderPass(const DeviceState& dev,
+                                   const ResourceFormats& fmts,
                                    bool color_output,
                                    bool depth_output)
 {
@@ -109,58 +107,38 @@ static VkRenderPass makeRenderPass(const DeviceState &dev,
     vector<VkAttachmentReference> attachment_refs;
 
     if (color_output) {
-        attachment_descs.push_back({
-            0,
-            fmts.colorAttachment,
-            VK_SAMPLE_COUNT_1_BIT,
-            VK_ATTACHMENT_LOAD_OP_CLEAR,
-            VK_ATTACHMENT_STORE_OP_STORE,
-            VK_ATTACHMENT_LOAD_OP_DONT_CARE,
-            VK_ATTACHMENT_STORE_OP_DONT_CARE,
-            VK_IMAGE_LAYOUT_UNDEFINED,
-            VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL
-        });
+        attachment_descs.push_back(
+            {0, fmts.colorAttachment, VK_SAMPLE_COUNT_1_BIT,
+             VK_ATTACHMENT_LOAD_OP_CLEAR, VK_ATTACHMENT_STORE_OP_STORE,
+             VK_ATTACHMENT_LOAD_OP_DONT_CARE, VK_ATTACHMENT_STORE_OP_DONT_CARE,
+             VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL});
 
-        attachment_refs.push_back({
-            0, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL
-        });
+        attachment_refs.push_back(
+            {0, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL});
     }
 
     if (depth_output) {
-        attachment_descs.push_back({
-            0,
-            fmts.linearDepthAttachment,
-            VK_SAMPLE_COUNT_1_BIT,
-            VK_ATTACHMENT_LOAD_OP_CLEAR,
-            VK_ATTACHMENT_STORE_OP_STORE,
-            VK_ATTACHMENT_LOAD_OP_DONT_CARE,
-            VK_ATTACHMENT_STORE_OP_DONT_CARE,
-            VK_IMAGE_LAYOUT_UNDEFINED,
-            VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL
-        });
+        attachment_descs.push_back(
+            {0, fmts.linearDepthAttachment, VK_SAMPLE_COUNT_1_BIT,
+             VK_ATTACHMENT_LOAD_OP_CLEAR, VK_ATTACHMENT_STORE_OP_STORE,
+             VK_ATTACHMENT_LOAD_OP_DONT_CARE, VK_ATTACHMENT_STORE_OP_DONT_CARE,
+             VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL});
 
-        attachment_refs.push_back({
-            static_cast<uint32_t>(attachment_refs.size()),
-            VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL
-        });
+        attachment_refs.push_back(
+            {static_cast<uint32_t>(attachment_refs.size()),
+             VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL});
     }
 
-    attachment_descs.push_back({
-        0,
-        fmts.depthAttachment,
-        VK_SAMPLE_COUNT_1_BIT,
-        VK_ATTACHMENT_LOAD_OP_CLEAR,
-        VK_ATTACHMENT_STORE_OP_DONT_CARE,
-        VK_ATTACHMENT_LOAD_OP_DONT_CARE,
-        VK_ATTACHMENT_STORE_OP_DONT_CARE,
-        VK_IMAGE_LAYOUT_UNDEFINED,
-        VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL
-    });
+    attachment_descs.push_back(
+        {0, fmts.depthAttachment, VK_SAMPLE_COUNT_1_BIT,
+         VK_ATTACHMENT_LOAD_OP_CLEAR, VK_ATTACHMENT_STORE_OP_DONT_CARE,
+         VK_ATTACHMENT_LOAD_OP_DONT_CARE, VK_ATTACHMENT_STORE_OP_DONT_CARE,
+         VK_IMAGE_LAYOUT_UNDEFINED,
+         VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL});
 
-    attachment_refs.push_back({
-        static_cast<uint32_t>(attachment_refs.size()),
-        VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL
-    });
+    attachment_refs.push_back(
+        {static_cast<uint32_t>(attachment_refs.size()),
+         VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL});
 
     VkSubpassDescription subpass_desc {};
     subpass_desc.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
@@ -182,13 +160,13 @@ static VkRenderPass makeRenderPass(const DeviceState &dev,
     render_pass_info.pDependencies = nullptr;
 
     VkRenderPass render_pass;
-    REQ_VK(dev.dt.createRenderPass(dev.hdl, &render_pass_info,
-                                   nullptr, &render_pass));
+    REQ_VK(dev.dt.createRenderPass(dev.hdl, &render_pass_info, nullptr,
+                                   &render_pass));
 
     return render_pass;
 }
 
-static VkSampler makeImmutableSampler(const DeviceState &dev)
+static VkSampler makeImmutableSampler(const DeviceState& dev)
 {
     VkSampler sampler;
 
@@ -212,32 +190,31 @@ static VkSampler makeImmutableSampler(const DeviceState &dev)
     sampler_info.borderColor = VK_BORDER_COLOR_FLOAT_OPAQUE_BLACK;
     sampler_info.unnormalizedCoordinates = VK_FALSE;
 
-    REQ_VK(dev.dt.createSampler(dev.hdl, &sampler_info,
-                                nullptr, &sampler));
+    REQ_VK(dev.dt.createSampler(dev.hdl, &sampler_info, nullptr, &sampler));
 
     return sampler;
 }
 
-static ParamBufferConfig computeParamBufferConfig(
-        bool need_materials, bool need_lighting,
-        uint32_t batch_size, const MemoryAllocator &alloc)
+static ParamBufferConfig computeParamBufferConfig(bool need_materials,
+                                                  bool need_lighting,
+                                                  uint32_t batch_size,
+                                                  const MemoryAllocator& alloc)
 {
     ParamBufferConfig cfg {};
 
-    cfg.totalTransformBytes = sizeof(glm::mat4x3) * 
-        VulkanConfig::max_instances;
+    cfg.totalTransformBytes =
+        sizeof(glm::mat4x3) * VulkanConfig::max_instances;
 
     VkDeviceSize cur_offset = cfg.totalTransformBytes;
 
     if (need_materials) {
         cfg.materialIndicesOffset = cur_offset;
 
-        cfg.totalMaterialIndexBytes = sizeof(uint32_t) *
-            VulkanConfig::max_instances;
+        cfg.totalMaterialIndexBytes =
+            sizeof(uint32_t) * VulkanConfig::max_instances;
 
         cur_offset = cfg.materialIndicesOffset + cfg.totalMaterialIndexBytes;
     }
-
 
     cfg.viewOffset = alloc.alignUniformBufferOffset(cur_offset);
     cfg.totalViewBytes = sizeof(ViewInfo) * batch_size;
@@ -246,8 +223,9 @@ static ParamBufferConfig computeParamBufferConfig(
 
     if (need_lighting) {
         cfg.lightsOffset = alloc.alignUniformBufferOffset(cur_offset);
-        cfg.totalLightParamBytes = sizeof(LightProperties) *
-            VulkanConfig::max_lights + sizeof(uint32_t);
+        cfg.totalLightParamBytes =
+            sizeof(LightProperties) * VulkanConfig::max_lights +
+            sizeof(uint32_t);
 
         cur_offset = cfg.lightsOffset + cfg.totalLightParamBytes;
     }
@@ -256,33 +234,35 @@ static ParamBufferConfig computeParamBufferConfig(
     cfg.totalParamBytes = alloc.alignStorageBufferOffset(
         alloc.alignUniformBufferOffset(cur_offset));
 
-    return  cfg;
+    return cfg;
 }
 
 template <typename PipelineType>
 RenderState PipelineImpl<PipelineType>::makeRenderState(
-        const DeviceState &dev, uint32_t batch_size,
-        uint32_t num_streams, const RenderOptions &opts,
-        MemoryAllocator &alloc)
+    const DeviceState& dev,
+    uint32_t batch_size,
+    uint32_t num_streams,
+    const RenderOptions& opts,
+    MemoryAllocator& alloc)
 {
     using Props = PipelineProps<PipelineType>;
 
     ParamBufferConfig param_positions = computeParamBufferConfig(
-            Props::needMaterial, Props::needLighting, batch_size, alloc);
+        Props::needMaterial, Props::needLighting, batch_size, alloc);
 
     using FrameLayout = typename Props::PerFrameLayout;
-    array<VkSampler *, FrameLayout::NumBindings> frame_layout_args;
+    array<VkSampler*, FrameLayout::NumBindings> frame_layout_args;
     frame_layout_args.fill(nullptr);
 
-    VkDescriptorSetLayout frame_descriptor_layout = apply([&](auto ...args) {
-        return FrameLayout::makeSetLayout(dev, args...);
-    }, frame_layout_args);
+    VkDescriptorSetLayout frame_descriptor_layout = apply(
+        [&](auto... args) { return FrameLayout::makeSetLayout(dev, args...); },
+        frame_layout_args);
 
     const uint32_t frames_per_stream =
         (opts & RenderOptions::DoubleBuffered) ? 2 : 1;
 
-    VkDescriptorPool frame_descriptor_pool = FrameLayout::makePool(
-            dev, num_streams * frames_per_stream);
+    VkDescriptorPool frame_descriptor_pool =
+        FrameLayout::makePool(dev, num_streams * frames_per_stream);
 
     VkSampler texture_sampler = VK_NULL_HANDLE;
     VkDescriptorSetLayout scene_descriptor_layout = VK_NULL_HANDLE;
@@ -291,8 +271,7 @@ RenderState PipelineImpl<PipelineType>::makeRenderState(
     if constexpr (Props::needMaterial) {
         using SceneLayout = typename Props::PerSceneLayout;
 
-
-        array<VkSampler *, SceneLayout::NumBindings> layout_args;
+        array<VkSampler*, SceneLayout::NumBindings> layout_args;
         layout_args.fill(nullptr);
 
         if constexpr (Props::needTextures) {
@@ -300,38 +279,38 @@ RenderState PipelineImpl<PipelineType>::makeRenderState(
             layout_args[0] = &texture_sampler;
         }
 
-        scene_descriptor_layout = apply([&](auto ...args) {
-            return SceneLayout::makeSetLayout(dev, args...);
-        }, layout_args);
+        scene_descriptor_layout = apply(
+            [&](auto... args) {
+                return SceneLayout::makeSetLayout(dev, args...);
+            },
+            layout_args);
 
         make_scene_pool = SceneLayout::makePool;
     }
 
-    return {
-        param_positions,
-        frame_descriptor_layout,
-        frame_descriptor_pool,
-        scene_descriptor_layout,
-        make_scene_pool,
-        texture_sampler,
-        makeRenderPass(dev, alloc.getFormats(),
-                       Props::needColorOutput,
-                       Props::needDepthOutput)
-    };
+    return {param_positions,
+            frame_descriptor_layout,
+            frame_descriptor_pool,
+            scene_descriptor_layout,
+            make_scene_pool,
+            texture_sampler,
+            makeRenderPass(dev, alloc.getFormats(), Props::needColorOutput,
+                           Props::needDepthOutput)};
 }
 
-static FramebufferState makeFramebuffer(const DeviceState &dev,
-                                        MemoryAllocator &alloc,
-                                        const FramebufferConfig &fb_cfg,
+static FramebufferState makeFramebuffer(const DeviceState& dev,
+                                        MemoryAllocator& alloc,
+                                        const FramebufferConfig& fb_cfg,
                                         VkRenderPass render_pass)
 {
     vector<LocalImage> attachments;
     vector<VkImageView> attachment_views;
+    vector<VkImageMemoryBarrier> fb_barriers;
 
     VkImageViewCreateInfo view_info {};
     view_info.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
     view_info.viewType = VK_IMAGE_VIEW_TYPE_2D;
-    VkImageSubresourceRange &view_info_sr = view_info.subresourceRange;
+    VkImageSubresourceRange& view_info_sr = view_info.subresourceRange;
     view_info_sr.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
     view_info_sr.baseMipLevel = 0;
     view_info_sr.levelCount = 1;
@@ -340,44 +319,41 @@ static FramebufferState makeFramebuffer(const DeviceState &dev,
 
     if (fb_cfg.colorOutput) {
         attachments.emplace_back(
-                alloc.makeColorAttachment(fb_cfg.totalWidth,
-                                          fb_cfg.totalHeight));
+            alloc.makeColorAttachment(fb_cfg.totalWidth, fb_cfg.totalHeight));
 
         VkImageView color_view;
         view_info.image = attachments.back().image;
         view_info.format = alloc.getFormats().colorAttachment;
 
-        REQ_VK(dev.dt.createImageView(dev.hdl, &view_info,
-                                      nullptr, &color_view));
+        REQ_VK(
+            dev.dt.createImageView(dev.hdl, &view_info, nullptr, &color_view));
 
         attachment_views.push_back(color_view);
     }
 
     if (fb_cfg.depthOutput) {
-        attachments.emplace_back(
-            alloc.makeLinearDepthAttachment(fb_cfg.totalWidth,
-                                            fb_cfg.totalHeight));
+        attachments.emplace_back(alloc.makeLinearDepthAttachment(
+            fb_cfg.totalWidth, fb_cfg.totalHeight));
 
         VkImageView linear_depth_view;
         view_info.image = attachments.back().image;
         view_info.format = alloc.getFormats().linearDepthAttachment;
 
-        REQ_VK(dev.dt.createImageView(dev.hdl, &view_info,
-                                      nullptr, &linear_depth_view));
+        REQ_VK(dev.dt.createImageView(dev.hdl, &view_info, nullptr,
+                                      &linear_depth_view));
 
         attachment_views.push_back(linear_depth_view);
     }
 
     attachments.emplace_back(
-            alloc.makeDepthAttachment(fb_cfg.totalWidth, fb_cfg.totalHeight));
+        alloc.makeDepthAttachment(fb_cfg.totalWidth, fb_cfg.totalHeight));
 
     view_info.image = attachments.back().image;
     view_info.format = alloc.getFormats().depthAttachment;
     view_info_sr.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;
 
     VkImageView depth_view;
-    REQ_VK(dev.dt.createImageView(dev.hdl, &view_info,
-                                  nullptr, &depth_view));
+    REQ_VK(dev.dt.createImageView(dev.hdl, &view_info, nullptr, &depth_view));
 
     attachment_views.push_back(depth_view);
 
@@ -395,23 +371,46 @@ static FramebufferState makeFramebuffer(const DeviceState &dev,
     VkFramebuffer fb_handle;
     REQ_VK(dev.dt.createFramebuffer(dev.hdl, &fb_info, nullptr, &fb_handle));
 
-    auto result_buffer =
-        alloc.makeHostBuffer(fb_cfg.totalLinearBytes);
+    auto result_buffer = alloc.makeResultsBuffer(fb_cfg.totalLinearBytes);
 
-    return FramebufferState {
-        move(attachments),
-        attachment_views,
-        fb_handle,
-        move(result_buffer),
-        VK_NULL_HANDLE
-    };
+    if (fb_cfg.colorOutput) {
+        fb_barriers.emplace_back(
+            VkImageMemoryBarrier {VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+                                  nullptr,
+                                  VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+                                  VK_ACCESS_TRANSFER_READ_BIT,
+                                  VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+                                  VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+                                  VK_QUEUE_FAMILY_IGNORED,
+                                  VK_QUEUE_FAMILY_IGNORED,
+                                  attachments[0].image,
+                                  {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1}});
+    }
+
+    if (fb_cfg.depthOutput) {
+        fb_barriers.emplace_back(
+            VkImageMemoryBarrier {VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+                                  nullptr,
+                                  VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+                                  VK_ACCESS_TRANSFER_READ_BIT,
+                                  VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+                                  VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+                                  VK_QUEUE_FAMILY_IGNORED,
+                                  VK_QUEUE_FAMILY_IGNORED,
+                                  attachments[attachments.size() - 2].image,
+                                  {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1}});
+    }
+
+    return FramebufferState {move(attachments),   attachment_views,
+                             move(fb_barriers),   fb_handle,
+                             move(result_buffer), VK_NULL_HANDLE};
 }
 
-static VkShaderModule loadShader(const DeviceState &dev,
-                                 const string &base_name)
+static VkShaderModule loadShader(const DeviceState& dev,
+                                 const string& base_name)
 {
     const string full_path = string(STRINGIFY(SHADER_DIR)) + base_name;
-    
+
     ifstream shader_file(full_path, ios::binary | ios::ate);
 
     streampos fend = shader_file.tellg();
@@ -433,7 +432,7 @@ static VkShaderModule loadShader(const DeviceState &dev,
     shader_info.pNext = nullptr;
     shader_info.flags = 0;
     shader_info.codeSize = file_size;
-    shader_info.pCode = reinterpret_cast<const uint32_t *>(shader_code.data());
+    shader_info.pCode = reinterpret_cast<const uint32_t*>(shader_code.data());
 
     VkShaderModule shader_module;
     REQ_VK(dev.dt.createShaderModule(dev.hdl, &shader_info, nullptr,
@@ -444,9 +443,9 @@ static VkShaderModule loadShader(const DeviceState &dev,
 
 template <typename PipelineType>
 PipelineState PipelineImpl<PipelineType>::makePipeline(
-        const DeviceState &dev,
-        const FramebufferConfig &fb_cfg,
-        const RenderState &render_state)
+    const DeviceState& dev,
+    const FramebufferConfig& fb_cfg,
+    const RenderState& render_state)
 {
     using Props = PipelineProps<PipelineType>;
     using VertexType = typename PipelineType::Vertex;
@@ -455,23 +454,19 @@ PipelineState PipelineImpl<PipelineType>::makePipeline(
     constexpr size_t num_bindings = Props::needMaterial ? 3 : 2;
 
     array<VkVertexInputBindingDescription, num_bindings> input_bindings;
-    input_bindings[0] = {
-        0, sizeof(VertexType), VK_VERTEX_INPUT_RATE_VERTEX
-    };
+    input_bindings[0] = {0, sizeof(VertexType), VK_VERTEX_INPUT_RATE_VERTEX};
 
-    input_bindings[1] = {
-        1, sizeof(glm::mat4x3), VK_VERTEX_INPUT_RATE_INSTANCE
-    };
+    input_bindings[1] = {1, sizeof(glm::mat4x3),
+                         VK_VERTEX_INPUT_RATE_INSTANCE};
 
     if constexpr (Props::needMaterial) {
-        input_bindings[2] = {
-            2, sizeof(uint32_t), VK_VERTEX_INPUT_RATE_INSTANCE
-        };
+        input_bindings[2] = {2, sizeof(uint32_t),
+                             VK_VERTEX_INPUT_RATE_INSTANCE};
     }
 
-    const auto &vertex_attributes = Props::vertexAttributes;
-    constexpr size_t total_attributes = vertex_attributes.size() +
-        3 + (Props::needMaterial ? 1 : 0);
+    const auto& vertex_attributes = Props::vertexAttributes;
+    constexpr size_t total_attributes =
+        vertex_attributes.size() + 3 + (Props::needMaterial ? 1 : 0);
 
     array<VkVertexInputAttributeDescription, total_attributes>
         input_attributes;
@@ -485,17 +480,14 @@ PipelineState PipelineImpl<PipelineType>::makePipeline(
         input_attributes[attr_idx] = {
             Props::transformLocationVertex + idx_offset, 1,
             VK_FORMAT_R32G32B32A32_SFLOAT,
-            static_cast<uint32_t>(idx_offset * sizeof(glm::vec4))
-        };
+            static_cast<uint32_t>(idx_offset * sizeof(glm::vec4))};
     }
 
     // FIXME (normal matrix)
 
     if constexpr (Props::needMaterial) {
         input_attributes[input_attributes.size() - 1] = {
-            Props::materialLocationVertex, 2,
-            VK_FORMAT_R32_UINT, 0
-        };
+            Props::materialLocationVertex, 2, VK_FORMAT_R32_UINT, 0};
     }
 
     constexpr size_t total_layouts = Props::needMaterial ? 2 : 1;
@@ -511,22 +503,20 @@ PipelineState PipelineImpl<PipelineType>::makePipeline(
     VkPipelineCacheCreateInfo pcache_info {};
     pcache_info.sType = VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO;
     VkPipelineCache pipeline_cache;
-    REQ_VK(dev.dt.createPipelineCache(dev.hdl, &pcache_info,
-                                      nullptr, &pipeline_cache));
+    REQ_VK(dev.dt.createPipelineCache(dev.hdl, &pcache_info, nullptr,
+                                      &pipeline_cache));
 
     constexpr size_t num_shaders = 2;
 
-    const array<pair<const char *, VkShaderStageFlagBits>,
-                num_shaders> shader_cfg {{
-        {Props::vertexShaderName, VK_SHADER_STAGE_VERTEX_BIT},
-        {Props::fragmentShaderName, VK_SHADER_STAGE_FRAGMENT_BIT}
-    }};
+    const array<pair<const char*, VkShaderStageFlagBits>, num_shaders>
+        shader_cfg {
+            {{Props::vertexShaderName, VK_SHADER_STAGE_VERTEX_BIT},
+             {Props::fragmentShaderName, VK_SHADER_STAGE_FRAGMENT_BIT}}};
 
     vector<VkShaderModule> shader_modules(num_shaders);
     array<VkPipelineShaderStageCreateInfo, num_shaders> shader_stages;
 
-    for (size_t shader_idx = 0; shader_idx < shader_cfg.size();
-         shader_idx++) {
+    for (size_t shader_idx = 0; shader_idx < shader_cfg.size(); shader_idx++) {
         auto [shader_name, shader_stage_flag] = shader_cfg[shader_idx];
 
         shader_modules[shader_idx] = loadShader(dev, shader_name);
@@ -538,8 +528,7 @@ PipelineState PipelineImpl<PipelineType>::makePipeline(
             shader_stage_flag,
             shader_modules[shader_idx],
             "main",
-            nullptr
-        };
+            nullptr};
     }
 
     VkPipelineVertexInputStateCreateInfo vert_info;
@@ -553,20 +542,16 @@ PipelineState PipelineImpl<PipelineType>::makePipeline(
     vert_info.vertexAttributeDescriptionCount =
         static_cast<uint32_t>(input_attributes.size());
     vert_info.pVertexAttributeDescriptions = input_attributes.data();
-    
+
     // Assembly
     VkPipelineInputAssemblyStateCreateInfo input_assembly_info {};
     input_assembly_info.sType =
         VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO;
-    input_assembly_info.topology =
-        VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
+    input_assembly_info.topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
     input_assembly_info.primitiveRestartEnable = VK_FALSE;
 
     // Viewport
-    VkRect2D scissors {
-        { 0, 0 },
-        { fb_cfg.totalWidth, fb_cfg.totalHeight }
-    };
+    VkRect2D scissors {{0, 0}, {fb_cfg.totalWidth, fb_cfg.totalHeight}};
 
     VkPipelineViewportStateCreateInfo viewport_info {};
     viewport_info.sType =
@@ -578,7 +563,7 @@ PipelineState PipelineImpl<PipelineType>::makePipeline(
 
     // Multisample
     VkPipelineMultisampleStateCreateInfo multisample_info {};
-    multisample_info.sType = 
+    multisample_info.sType =
         VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO;
     multisample_info.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
     multisample_info.sampleShadingEnable = VK_FALSE;
@@ -596,7 +581,7 @@ PipelineState PipelineImpl<PipelineType>::makePipeline(
     raster_info.frontFace = VK_FRONT_FACE_COUNTER_CLOCKWISE;
     raster_info.depthBiasEnable = VK_FALSE;
     raster_info.lineWidth = 1.0f;
-    
+
     // Depth/Stencil
     VkPipelineDepthStencilStateCreateInfo depth_info {};
     depth_info.sType =
@@ -612,10 +597,8 @@ PipelineState PipelineImpl<PipelineType>::makePipeline(
     VkPipelineColorBlendAttachmentState blend_attach {};
     blend_attach.blendEnable = VK_FALSE;
     blend_attach.colorWriteMask =
-        VK_COLOR_COMPONENT_R_BIT |
-        VK_COLOR_COMPONENT_G_BIT |
-        VK_COLOR_COMPONENT_B_BIT |
-        VK_COLOR_COMPONENT_A_BIT;
+        VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT |
+        VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT;
 
     vector<VkPipelineColorBlendAttachmentState> blend_attachments;
     if (fb_cfg.colorOutput) {
@@ -645,15 +628,13 @@ PipelineState PipelineImpl<PipelineType>::makePipeline(
     // Push constant
     VkPushConstantRange push_const {
         VK_SHADER_STAGE_VERTEX_BIT |
-            VK_SHADER_STAGE_FRAGMENT_BIT, // FIXME this isn't necessary for all pipelines
-        0,
-        sizeof(RenderPushConstant)
-    };
+            VK_SHADER_STAGE_FRAGMENT_BIT,  // FIXME this isn't necessary for
+                                           // all pipelines
+        0, sizeof(RenderPushConstant)};
 
     // Layout configuration
     VkPipelineLayoutCreateInfo pipeline_layout_info;
-    pipeline_layout_info.sType =
-        VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
+    pipeline_layout_info.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
     pipeline_layout_info.pNext = nullptr;
     pipeline_layout_info.flags = 0;
     pipeline_layout_info.setLayoutCount =
@@ -663,9 +644,8 @@ PipelineState PipelineImpl<PipelineType>::makePipeline(
     pipeline_layout_info.pPushConstantRanges = &push_const;
 
     VkPipelineLayout pipeline_layout;
-    REQ_VK(dev.dt.createPipelineLayout(dev.hdl, &pipeline_layout_info,
-                                       nullptr, &pipeline_layout));
-
+    REQ_VK(dev.dt.createPipelineLayout(dev.hdl, &pipeline_layout_info, nullptr,
+                                       &pipeline_layout));
 
     VkGraphicsPipelineCreateInfo pipeline_info;
     pipeline_info.sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
@@ -690,30 +670,24 @@ PipelineState PipelineImpl<PipelineType>::makePipeline(
 
     VkPipeline pipeline;
     REQ_VK(dev.dt.createGraphicsPipelines(dev.hdl, pipeline_cache, 1,
-                                          &pipeline_info, nullptr,
-                                          &pipeline));
+                                          &pipeline_info, nullptr, &pipeline));
 
-    return PipelineState {
-        shader_modules,
-        pipeline_cache,
-        pipeline_layout,
-        pipeline
-    };
+    return PipelineState {shader_modules, pipeline_cache, pipeline_layout,
+                          pipeline};
 }
 
 static glm::u32vec2 computeFBPosition(uint32_t batch_idx,
-                                      const FramebufferConfig &cfg)
+                                      const FramebufferConfig& cfg)
 {
-    return glm::u32vec2((batch_idx % cfg.numImagesWidePerBatch) *
-                        cfg.imgWidth,
-                        (batch_idx / cfg.numImagesWidePerBatch) *
-                        cfg.imgHeight);
+    return glm::u32vec2(
+        (batch_idx % cfg.numImagesWidePerBatch) * cfg.imgWidth,
+        (batch_idx / cfg.numImagesWidePerBatch) * cfg.imgHeight);
 }
 
-static PerFrameState makeFrameState(const DeviceState &dev,
-                                    const FramebufferConfig &fb_cfg,
-                                    const ParamBufferConfig &param_config,
-                                    const HostBuffer &param_buffer,
+static PerFrameState makeFrameState(const DeviceState& dev,
+                                    const FramebufferConfig& fb_cfg,
+                                    const ParamBufferConfig& param_config,
+                                    const HostBuffer& param_buffer,
                                     VkCommandPool gfx_pool,
                                     VkDescriptorPool frame_set_pool,
                                     VkDescriptorSetLayout frame_set_layout,
@@ -724,13 +698,11 @@ static PerFrameState makeFrameState(const DeviceState &dev,
                                     uint32_t stream_idx)
 {
     VkCommandBuffer render_command = makeCmdBuffer(dev, gfx_pool);
-    VkCommandBuffer copy_command = makeCmdBuffer(dev, gfx_pool);
 
     uint32_t global_frame_idx = stream_idx * num_frames_per_stream + frame_idx;
 
     glm::u32vec2 base_fb_offset(
-            global_frame_idx * fb_cfg.numImagesWidePerBatch * fb_cfg.imgWidth,
-            0);
+        global_frame_idx * fb_cfg.numImagesWidePerBatch * fb_cfg.imgWidth, 0);
 
     DynArray<glm::u32vec2> batch_fb_offsets(batch_size);
     for (uint32_t batch_idx = 0; batch_idx < batch_size; batch_idx++) {
@@ -738,17 +710,50 @@ static PerFrameState makeFrameState(const DeviceState &dev,
             computeFBPosition(batch_idx, fb_cfg) + base_fb_offset;
     }
 
+    DynArray<VkBufferImageCopy> color_copy_regions(
+        fb_cfg.colorOutput ? batch_size : 0);
+    DynArray<VkBufferImageCopy> depth_copy_regions(
+        fb_cfg.depthOutput ? batch_size : 0);
+    auto make_copy_cmd = [&](VkDeviceSize base_offset, uint32_t texel_bytes,
+                             DynArray<VkBufferImageCopy>& copy_regions) {
+        uint32_t cur_offset = base_offset;
+
+        for (uint32_t batch_idx = 0; batch_idx < batch_size; batch_idx++) {
+            glm::u32vec2 cur_fb_pos = batch_fb_offsets[batch_idx];
+
+            VkBufferImageCopy& region = copy_regions[batch_idx];
+            region.bufferOffset = cur_offset;
+            region.bufferRowLength = 0;
+            region.bufferImageHeight = 0;
+            region.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+            region.imageOffset = {static_cast<int32_t>(cur_fb_pos.x),
+                                  static_cast<int32_t>(cur_fb_pos.y), 0};
+            region.imageExtent = {fb_cfg.imgWidth, fb_cfg.imgHeight, 1};
+
+            cur_offset += fb_cfg.imgWidth * fb_cfg.imgHeight * texel_bytes;
+        }
+    };
+
     VkDeviceSize color_buffer_offset =
         global_frame_idx * fb_cfg.linearBytesPerFrame;
 
     VkDeviceSize depth_buffer_offset =
         color_buffer_offset + fb_cfg.colorLinearBytesPerFrame;
 
+    if (fb_cfg.colorOutput) {
+        make_copy_cmd(color_buffer_offset, sizeof(uint8_t) * 4,
+                      color_copy_regions);
+    }
+
+    if (fb_cfg.depthOutput) {
+        make_copy_cmd(depth_buffer_offset, sizeof(float), depth_copy_regions);
+    }
+
     const bool use_materials = param_config.totalMaterialIndexBytes > 0;
     const bool use_lights = param_config.totalLightParamBytes > 0;
 
-    VkDescriptorSet frame_set = makeDescriptorSet(dev, frame_set_pool,
-                                                  frame_set_layout);
+    VkDescriptorSet frame_set =
+        makeDescriptorSet(dev, frame_set_pool, frame_set_layout);
     vector<VkWriteDescriptorSet> frame_set_updates;
 
     const size_t num_vertex_inputs = use_materials ? 3 : 2;
@@ -766,19 +771,17 @@ static PerFrameState makeFrameState(const DeviceState &dev,
     vertex_buffers[1] = param_buffer.buffer;
     vertex_offsets[1] = base_offset;
 
-    uint8_t *base_ptr = reinterpret_cast<uint8_t *>(param_buffer.ptr) +
-        base_offset;
+    uint8_t* base_ptr =
+        reinterpret_cast<uint8_t*>(param_buffer.ptr) + base_offset;
 
-    glm::mat4x3 *transform_ptr = reinterpret_cast<glm::mat4x3 *>(base_ptr);
+    glm::mat4x3* transform_ptr = reinterpret_cast<glm::mat4x3*>(base_ptr);
 
-    ViewInfo *view_ptr = reinterpret_cast<ViewInfo *>(
-            base_ptr + param_config.viewOffset);
+    ViewInfo* view_ptr =
+        reinterpret_cast<ViewInfo*>(base_ptr + param_config.viewOffset);
 
     VkDescriptorBufferInfo view_buffer_info = {
-        param_buffer.buffer,
-        base_offset + param_config.viewOffset,
-        param_config.totalViewBytes
-    };
+        param_buffer.buffer, base_offset + param_config.viewOffset,
+        param_config.totalViewBytes};
 
     VkWriteDescriptorSet binding_update;
     binding_update.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
@@ -793,13 +796,13 @@ static PerFrameState makeFrameState(const DeviceState &dev,
     binding_update.pTexelBufferView = nullptr;
     frame_set_updates.push_back(binding_update);
 
-    uint32_t *material_ptr = nullptr;
-    LightProperties *light_ptr = nullptr;
-    uint32_t *num_lights_ptr = nullptr;
+    uint32_t* material_ptr = nullptr;
+    LightProperties* light_ptr = nullptr;
+    uint32_t* num_lights_ptr = nullptr;
 
     if (use_materials) {
-        material_ptr = reinterpret_cast<uint32_t *>(
-                base_ptr + param_config.materialIndicesOffset);
+        material_ptr = reinterpret_cast<uint32_t*>(
+            base_ptr + param_config.materialIndicesOffset);
 
         vertex_buffers[2] = param_buffer.buffer;
         vertex_offsets[2] = base_offset + param_config.materialIndicesOffset;
@@ -807,17 +810,15 @@ static PerFrameState makeFrameState(const DeviceState &dev,
 
     VkDescriptorBufferInfo light_info;
     if (use_lights) {
-        light_ptr = reinterpret_cast<LightProperties *>(
-                base_ptr + param_config.lightsOffset);
+        light_ptr = reinterpret_cast<LightProperties*>(
+            base_ptr + param_config.lightsOffset);
 
-        num_lights_ptr = reinterpret_cast<uint32_t *>(
-                light_ptr + VulkanConfig::max_lights);
+        num_lights_ptr =
+            reinterpret_cast<uint32_t*>(light_ptr + VulkanConfig::max_lights);
 
-        light_info = {
-            param_buffer.buffer,
-            base_offset + param_config.lightsOffset,
-            param_config.totalLightParamBytes
-        };
+        light_info = {param_buffer.buffer,
+                      base_offset + param_config.lightsOffset,
+                      param_config.totalLightParamBytes};
 
         binding_update.dstBinding = 1;
         binding_update.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
@@ -825,153 +826,70 @@ static PerFrameState makeFrameState(const DeviceState &dev,
         frame_set_updates.push_back(binding_update);
     }
 
-    dev.dt.updateDescriptorSets(dev.hdl,
-            static_cast<uint32_t>(frame_set_updates.size()),
-            frame_set_updates.data(), 0, nullptr);
+    dev.dt.updateDescriptorSets(
+        dev.hdl, static_cast<uint32_t>(frame_set_updates.size()),
+        frame_set_updates.data(), 0, nullptr);
 
-    return PerFrameState {
-        cpu_sync ? makeFence(dev) : VK_NULL_HANDLE,
-        { render_command, copy_command },
-        base_fb_offset,
-        move(batch_fb_offsets),
-        color_buffer_offset,
-        depth_buffer_offset,
-        frame_set,
-        move(vertex_buffers),
-        move(vertex_offsets),
-        transform_ptr,
-        view_ptr,
-        material_ptr,
-        light_ptr,
-        num_lights_ptr
-    };
+    return PerFrameState {cpu_sync ? makeFence(dev) : VK_NULL_HANDLE,
+                          {
+                              render_command,
+                          },
+                          base_fb_offset,
+                          move(batch_fb_offsets),
+                          move(color_copy_regions),
+                          move(depth_copy_regions),
+                          color_buffer_offset,
+                          depth_buffer_offset,
+                          frame_set,
+                          move(vertex_buffers),
+                          move(vertex_offsets),
+                          transform_ptr,
+                          view_ptr,
+                          material_ptr,
+                          light_ptr,
+                          num_lights_ptr};
 }
 
-static void recordFBToLinearCopy(const DeviceState &dev,
-                                 const PerFrameState &state,
-                                 const FramebufferConfig &fb_cfg,
-                                 const FramebufferState &fb)
+void impl::recordFBToLinearCopy(VkCommandBuffer& copy_cmd_buffer,
+                                const DeviceState& dev,
+                                const PerFrameState& state,
+                                const FramebufferConfig& fb_cfg,
+                                const FramebufferState& fb,
+                                const uint32_t num_drawn)
 {
-    // FIXME move this to FramebufferState
-    vector<VkImageMemoryBarrier> fb_barriers;
+    dev.dt.cmdPipelineBarrier(
+        copy_cmd_buffer, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+        VK_PIPELINE_STAGE_TRANSFER_BIT, VK_DEPENDENCY_BY_REGION_BIT, 0,
+        nullptr, 0, nullptr, static_cast<uint32_t>(fb.barriers.size()),
+        fb.barriers.data());
 
     if (fb_cfg.colorOutput) {
-        fb_barriers.emplace_back(VkImageMemoryBarrier {
-            VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
-            nullptr,
-            VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
-            VK_ACCESS_TRANSFER_READ_BIT,
-            VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
-            VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
-            VK_QUEUE_FAMILY_IGNORED,
-            VK_QUEUE_FAMILY_IGNORED,
-            fb.attachments[0].image,
-            {
-                VK_IMAGE_ASPECT_COLOR_BIT,
-                0, 1, 0, 1
-            }
-        });
-    }
-
-    if (fb_cfg.depthOutput) {
-        fb_barriers.emplace_back(VkImageMemoryBarrier {
-            VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
-            nullptr,
-            VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
-            VK_ACCESS_TRANSFER_READ_BIT,
-            VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
-            VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
-            VK_QUEUE_FAMILY_IGNORED,
-            VK_QUEUE_FAMILY_IGNORED,
-            fb.attachments[fb.attachments.size() - 2].image,
-            {
-                VK_IMAGE_ASPECT_COLOR_BIT,
-                0, 1, 0, 1
-            }
-        });
-    }
-
-    VkCommandBuffer copy_cmd = state.commands[1];
-
-    VkCommandBufferBeginInfo begin_info {};
-    begin_info.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
-    REQ_VK(dev.dt.beginCommandBuffer(copy_cmd, &begin_info));
-    dev.dt.cmdPipelineBarrier(copy_cmd,
-                              VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
-                              VK_PIPELINE_STAGE_TRANSFER_BIT,
-                              VK_DEPENDENCY_BY_REGION_BIT,
-                              0, nullptr, 0, nullptr,
-                              static_cast<uint32_t>(fb_barriers.size()),
-                              fb_barriers.data());
-
-    uint32_t batch_size = state.batchFBOffsets.size();
-
-    DynArray<VkBufferImageCopy> copy_regions(batch_size);
-
-    auto make_copy_cmd = [&](VkDeviceSize base_offset, uint32_t texel_bytes,
-                             VkImage src_image) {
-
-        uint32_t cur_offset = base_offset;
-
-        for (uint32_t batch_idx = 0; batch_idx < batch_size; batch_idx++) {
-            glm::u32vec2 cur_fb_pos = state.batchFBOffsets[batch_idx];
-
-            VkBufferImageCopy &region = copy_regions[batch_idx];
-            region.bufferOffset = cur_offset;
-            region.bufferRowLength = 0;
-            region.bufferImageHeight = 0;
-            region.imageSubresource = {
-                VK_IMAGE_ASPECT_COLOR_BIT,
-                0, 0, 1
-            };
-            region.imageOffset = {
-                static_cast<int32_t>(cur_fb_pos.x),
-                static_cast<int32_t>(cur_fb_pos.y),
-                0
-            };
-            region.imageExtent = {
-                fb_cfg.imgWidth,
-                fb_cfg.imgHeight,
-                1
-            };
-
-            cur_offset += fb_cfg.imgWidth * fb_cfg.imgHeight * texel_bytes;
-        }
-
-        dev.dt.cmdCopyImageToBuffer(copy_cmd,
-                                    src_image,
+        dev.dt.cmdCopyImageToBuffer(copy_cmd_buffer, fb.attachments[0].image,
                                     VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
-                                    fb.resultBuffer.buffer,
-                                    batch_size,
-                                    copy_regions.data());
-    };
-
-    if (fb_cfg.colorOutput) {
-        make_copy_cmd(state.colorBufferOffset, sizeof(uint8_t) * 4,
-                      fb.attachments[0].image);
+                                    fb.resultBuffer.buffer, num_drawn,
+                                    state.colorCopyRegions.data());
     }
 
     if (fb_cfg.depthOutput) {
-        make_copy_cmd(state.depthBufferOffset, sizeof(float),
-                      fb.attachments[fb.attachments.size() - 2].image);
+        dev.dt.cmdCopyImageToBuffer(
+            copy_cmd_buffer, fb.attachments[fb.attachments.size() - 2].image,
+            VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, fb.resultBuffer.buffer,
+            num_drawn, state.depthCopyRegions.data());
     }
-
-    REQ_VK(dev.dt.endCommandBuffer(copy_cmd));
 }
 
-CommandStreamState::CommandStreamState(
-        const InstanceState &i,
-        const DeviceState &d,
-        const FramebufferConfig &fb_cfg,
-        const RenderState &render_state,
-        const PipelineState &pl,
-        const FramebufferState &framebuffer,
-        MemoryAllocator &alc,
-        QueueManager &queue_manager,
-        uint32_t batch_size,
-        uint32_t stream_idx,
-        uint32_t num_frames_inflight,
-        bool cpu_sync)
+CommandStreamState::CommandStreamState(const InstanceState& i,
+                                       const DeviceState& d,
+                                       const FramebufferConfig& fb_cfg,
+                                       const RenderState& render_state,
+                                       const PipelineState& pl,
+                                       const FramebufferState& framebuffer,
+                                       MemoryAllocator& alc,
+                                       QueueManager& queue_manager,
+                                       uint32_t batch_size,
+                                       uint32_t stream_idx,
+                                       uint32_t num_frames_inflight,
+                                       bool cpu_sync)
     : inst(i),
       dev(d),
       pipeline(pl),
@@ -982,8 +900,7 @@ CommandStreamState::CommandStreamState(
       fb_(framebuffer),
       render_pass_(render_state.renderPass),
       per_render_buffer_(alloc.makeHostBuffer(
-                render_state.paramPositions.totalParamBytes *
-                    num_frames_inflight)),
+          render_state.paramPositions.totalParamBytes * num_frames_inflight)),
       render_size_(fb_cfg.imgWidth, fb_cfg.imgHeight),
       render_extent_(render_size_.x * fb_cfg.numImagesWidePerBatch,
                      render_size_.y * fb_cfg.numImagesTallPerBatch),
@@ -993,78 +910,76 @@ CommandStreamState::CommandStreamState(
     frame_states_.reserve(num_frames_inflight);
     for (uint32_t frame_idx = 0; frame_idx < num_frames_inflight;
          frame_idx++) {
-        frame_states_.emplace_back(makeFrameState(dev,
-                fb_cfg,
-                render_state.paramPositions,
-                per_render_buffer_,
-                gfxPool,
-                render_state.frameDescriptorPool,
-                render_state.frameDescriptorLayout,
-                cpu_sync, batch_size,
-                frame_idx, num_frames_inflight, stream_idx));
+        frame_states_.emplace_back(makeFrameState(
+            dev, fb_cfg, render_state.paramPositions, per_render_buffer_,
+            gfxPool, render_state.frameDescriptorPool,
+            render_state.frameDescriptorLayout, cpu_sync, batch_size,
+            frame_idx, num_frames_inflight, stream_idx));
 
-        recordFBToLinearCopy(dev, frame_states_.back(), fb_cfg_, fb_);
+        // recordFBToLinearCopy(dev, frame_states_.back(), fb_cfg_, fb_);
     }
-
 }
 
-uint32_t CommandStreamState::render(const vector<Environment> &envs)
+uint32_t CommandStreamState::render(const vector<Environment>& envs)
 {
-    return render(envs, [this](uint32_t frame_id,
-                               uint32_t num_commands,
-                               const VkCommandBuffer *commands,
-                               VkFence fence) {
-        (void)frame_id;
+    return render(envs,
+                  [this](uint32_t frame_id, uint32_t num_commands,
+                         const VkCommandBuffer* commands, VkFence fence) {
+                      (void)frame_id;
 
-        VkSubmitInfo gfx_submit {
-            VK_STRUCTURE_TYPE_SUBMIT_INFO,
-            nullptr,
-            0, nullptr, nullptr,
-            num_commands, commands,
-            0, nullptr
-        };
+                      VkSubmitInfo gfx_submit {VK_STRUCTURE_TYPE_SUBMIT_INFO,
+                                               nullptr,
+                                               0,
+                                               nullptr,
+                                               nullptr,
+                                               num_commands,
+                                               commands,
+                                               0,
+                                               nullptr};
 
-        gfxQueue.submit(dev, 1, &gfx_submit, fence);
-    });
+                      gfxQueue.submit(dev, 1, &gfx_submit, fence);
+                  });
 }
 
 template <typename PipelineType>
-VulkanState::VulkanState(const RenderConfig &config,
-                         const RenderFeatures<PipelineType> &features,
-                         const DeviceUUID &uuid)
+VulkanState::VulkanState(const RenderConfig& config,
+                         const RenderFeatures<PipelineType>& features,
+                         const DeviceUUID& uuid)
     : VulkanState(config, features, [&config, &uuid]() {
-        InstanceState inst_state(false, {});
-        DeviceState dev_state(
-                inst_state.makeDevice(uuid,
-                                      config.numStreams + config.numLoaders,
-                                      1,
-                                      config.numLoaders, nullptr));
-        return CoreVulkanHandles { move(inst_state), move(dev_state) };
-    }())
+          InstanceState inst_state(false, {});
+          DeviceState dev_state(inst_state.makeDevice(
+              uuid, config.numStreams + config.numLoaders, 1,
+              config.numLoaders, nullptr));
+          return CoreVulkanHandles {move(inst_state), move(dev_state)};
+      }())
 {}
 
 template <typename PipelineType>
-VulkanState::VulkanState(const RenderConfig &cfg,
-                         const RenderFeatures<PipelineType> &features,
-                         CoreVulkanHandles &&handles)
+VulkanState::VulkanState(const RenderConfig& cfg,
+                         const RenderFeatures<PipelineType>& features,
+                         CoreVulkanHandles&& handles)
     : inst(move(handles.inst)),
       dev(move(handles.dev)),
       queueMgr(dev),
       alloc(dev, inst),
-      fbCfg(PipelineImpl<PipelineType>::getFramebufferConfig(
-              cfg.batchSize, cfg.imgWidth,
-              cfg.imgHeight, cfg.numStreams,
-              features.options)),
-      renderState(PipelineImpl<PipelineType>::makeRenderState(
-              dev, cfg.batchSize, cfg.numStreams,
-              features.options, alloc)),
-      pipeline(PipelineImpl<PipelineType>::makePipeline(
-              dev, fbCfg, renderState)),
+      fbCfg(
+          PipelineImpl<PipelineType>::getFramebufferConfig(cfg.batchSize,
+                                                           cfg.imgWidth,
+                                                           cfg.imgHeight,
+                                                           cfg.numStreams,
+                                                           features.options)),
+      renderState(PipelineImpl<PipelineType>::makeRenderState(dev,
+                                                              cfg.batchSize,
+                                                              cfg.numStreams,
+                                                              features.options,
+                                                              alloc)),
+      pipeline(
+          PipelineImpl<PipelineType>::makePipeline(dev, fbCfg, renderState)),
       fb(makeFramebuffer(dev, alloc, fbCfg, renderState.renderPass)),
       globalTransform(cfg.coordinateTransform),
       loader_impl_(
-              LoaderImpl::create<typename PipelineType::Vertex,
-                                 typename PipelineType::MaterialParams>()),
+          LoaderImpl::create<typename PipelineType::Vertex,
+                             typename PipelineType::MaterialParams>()),
       num_loaders_(0),
       num_streams_(0),
       max_num_loaders_(cfg.numLoaders),
@@ -1079,10 +994,8 @@ LoaderState VulkanState::makeLoader()
     num_loaders_++;
     assert(num_loaders_ <= max_num_loaders_);
 
-    return LoaderState(dev, loader_impl_,
-                       renderState.sceneDescriptorLayout,
-                       renderState.makeScenePool,
-                       alloc, queueMgr,
+    return LoaderState(dev, loader_impl_, renderState.sceneDescriptorLayout,
+                       renderState.makeScenePool, alloc, queueMgr,
                        globalTransform);
 }
 
@@ -1093,18 +1006,9 @@ CommandStreamState VulkanState::makeStream()
 
     uint32_t num_frames_inflight = double_buffered_ ? 2 : 1;
 
-    return CommandStreamState(inst,
-                              dev,
-                              fbCfg,
-                              renderState,
-                              pipeline,
-                              fb,
-                              alloc,
-                              queueMgr,
-                              batch_size_,
-                              stream_idx,
-                              num_frames_inflight,
-                              cpu_sync_);
+    return CommandStreamState(inst, dev, fbCfg, renderState, pipeline, fb,
+                              alloc, queueMgr, batch_size_, stream_idx,
+                              num_frames_inflight, cpu_sync_);
 }
 
 int VulkanState::getFramebufferFD() const
@@ -1126,6 +1030,6 @@ uint64_t VulkanState::getFramebufferBytes() const
     return fbCfg.totalLinearBytes;
 }
 
-}
+}  // namespace v4r
 
 #include "render_instantiations.inl"

--- a/src/vulkan_state.inl
+++ b/src/vulkan_state.inl
@@ -7,11 +7,20 @@
 
 namespace v4r {
 
+namespace impl {
+void recordFBToLinearCopy(VkCommandBuffer& copy_command_buffer,
+                          const DeviceState& dev,
+                          const PerFrameState& state,
+                          const FramebufferConfig& fb_cfg,
+                          const FramebufferState& fb,
+                          uint32_t num_drawn);
+}
+
 template <typename Fn>
-uint32_t CommandStreamState::render(const std::vector<Environment> &envs,
-                                    Fn &&submit_func)
+uint32_t CommandStreamState::render(const std::vector<Environment>& envs,
+                                    Fn&& submit_func)
 {
-    PerFrameState &frame_state = frame_states_[cur_frame_];
+    PerFrameState& frame_state = frame_states_[cur_frame_];
 
     VkCommandBuffer render_cmd = frame_state.commands[0];
 
@@ -19,11 +28,9 @@ uint32_t CommandStreamState::render(const std::vector<Environment> &envs,
     begin_info.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
     REQ_VK(dev.dt.beginCommandBuffer(render_cmd, &begin_info));
 
-    dev.dt.cmdBindDescriptorSets(render_cmd,
-                                 VK_PIPELINE_BIND_POINT_GRAPHICS,
-                                 pipeline.gfxLayout, 0,
-                                 1, &frame_state.frameSet,
-                                 0, nullptr);
+    dev.dt.cmdBindDescriptorSets(render_cmd, VK_PIPELINE_BIND_POINT_GRAPHICS,
+                                 pipeline.gfxLayout, 0, 1,
+                                 &frame_state.frameSet, 0, nullptr);
 
     // FIXME
     dev.dt.cmdBindPipeline(render_cmd, VK_PIPELINE_BIND_POINT_GRAPHICS,
@@ -35,11 +42,9 @@ uint32_t CommandStreamState::render(const std::vector<Environment> &envs,
     render_begin.renderPass = render_pass_;
     render_begin.framebuffer = fb_.hdl;
     render_begin.renderArea.offset = {
-        static_cast<int32_t>(frame_state.baseFBOffset.x), 
-        static_cast<int32_t>(frame_state.baseFBOffset.y) 
-    };
-    render_begin.renderArea.extent = { render_extent_.x, 
-                                       render_extent_.y };
+        static_cast<int32_t>(frame_state.baseFBOffset.x),
+        static_cast<int32_t>(frame_state.baseFBOffset.y)};
+    render_begin.renderArea.extent = {render_extent_.x, render_extent_.y};
     render_begin.clearValueCount =
         static_cast<uint32_t>(fb_cfg_.clearValues.size());
     render_begin.pClearValues = fb_cfg_.clearValues.data();
@@ -47,49 +52,20 @@ uint32_t CommandStreamState::render(const std::vector<Environment> &envs,
     dev.dt.cmdBeginRenderPass(render_cmd, &render_begin,
                               VK_SUBPASS_CONTENTS_INLINE);
 
-    uint32_t cur_instance = 0;
-    glm::mat4x3 *transform_ptr = frame_state.transformPtr;
-    uint32_t *material_ptr = frame_state.materialPtr;
-    LightProperties *light_ptr = frame_state.lightPtr;
-    ViewInfo *view_ptr = frame_state.viewPtr;
-    for (uint32_t batch_idx = 0; batch_idx < envs.size(); batch_idx++) {
-        const Environment &env = envs[batch_idx];
+    uint32_t cur_instance = 0, batch_idx = 0, total_lights = 0;
+    glm::mat4x3* transform_ptr = frame_state.transformPtr;
+    uint32_t* material_ptr = frame_state.materialPtr;
+    LightProperties* light_ptr = frame_state.lightPtr;
+    ViewInfo* view_ptr = frame_state.viewPtr;
+    for (uint32_t env_idx = 0; env_idx < envs.size(); env_idx++) {
+        const Environment& env = envs[env_idx];
 
-        const Scene &scene = *(envs[batch_idx].state_->scene);
+        const Scene& scene = *(env.state_->scene);
         if (scene.materialSet.hdl != VK_NULL_HANDLE) {
-            dev.dt.cmdBindDescriptorSets(render_cmd,
-                                         VK_PIPELINE_BIND_POINT_GRAPHICS,
-                                         pipeline.gfxLayout, 1,
-                                         1, &scene.materialSet.hdl,
-                                         0, nullptr);
+            dev.dt.cmdBindDescriptorSets(
+                render_cmd, VK_PIPELINE_BIND_POINT_GRAPHICS,
+                pipeline.gfxLayout, 1, 1, &scene.materialSet.hdl, 0, nullptr);
         }
-
-        view_ptr->view = env.view_;
-        view_ptr->projection = env.state_->projection;
-        view_ptr++;
-
-        RenderPushConstant push_const {
-            batch_idx
-        };
-
-        dev.dt.cmdPushConstants(render_cmd, pipeline.gfxLayout,
-                                VK_SHADER_STAGE_VERTEX_BIT |
-                                    VK_SHADER_STAGE_FRAGMENT_BIT,
-                                0,
-                                sizeof(RenderPushConstant),
-                                &push_const);
-
-        glm::u32vec2 batch_offset = frame_state.batchFBOffsets[batch_idx];
-
-        VkViewport viewport;
-        viewport.x = batch_offset.x;
-        viewport.y = batch_offset.y;
-        viewport.width = render_size_.x;
-        viewport.height = render_size_.y;
-        viewport.minDepth = 0.f;
-        viewport.maxDepth = 1.f;
-
-        dev.dt.cmdSetViewport(render_cmd, 0, 1, &viewport);
 
         frame_state.vertexBuffers[0] = scene.data.buffer;
         dev.dt.cmdBindVertexBuffers(render_cmd, 0,
@@ -99,16 +75,13 @@ uint32_t CommandStreamState::render(const std::vector<Environment> &envs,
         dev.dt.cmdBindIndexBuffer(render_cmd, scene.data.buffer,
                                   scene.indexOffset, VK_INDEX_TYPE_UINT32);
 
+        std::vector<uint32_t> mesh_instance_offsets(scene.meshes.size(), 0);
         for (uint32_t mesh_idx = 0; mesh_idx < scene.meshes.size();
-                mesh_idx++) {
+             mesh_idx++) {
             uint32_t num_instances = env.transforms_[mesh_idx].size();
             if (num_instances == 0) continue;
 
-            auto &mesh = scene.meshes[mesh_idx];
-
-            dev.dt.cmdDrawIndexed(render_cmd, mesh.numIndices, num_instances,
-                                  mesh.startIndex, mesh.vertexOffset,
-                                  cur_instance);
+            mesh_instance_offsets[mesh_idx] = cur_instance;
 
             memcpy(transform_ptr, env.transforms_[mesh_idx].data(),
                    sizeof(glm::mat4x3) * num_instances);
@@ -124,39 +97,90 @@ uint32_t CommandStreamState::render(const std::vector<Environment> &envs,
             }
         }
 
+        uint32_t num_lights = 0, lights_offset = 0;
         if (light_ptr) {
-            uint32_t num_lights = env.state_->lights.size();
+            num_lights = env.state_->lights.size();
 
             memcpy(light_ptr, env.state_->lights.data(),
                    num_lights * sizeof(LightProperties));
 
             *frame_state.numLightsPtr = num_lights;
+            lights_offset = total_lights;
 
             light_ptr += num_lights;
+            total_lights += num_lights;
+        }
+
+        for (uint32_t view_idx = 0; view_idx < env.views_.size(); ++view_idx) {
+            if (!env.actives_[view_idx]) continue;
+
+            view_ptr->view = env.views_[view_idx];
+            view_ptr->projection = env.state_->projection;
+            view_ptr++;
+
+            RenderPushConstant push_const {
+                batch_idx,
+                lights_offset,
+                num_lights,
+            };
+
+            dev.dt.cmdPushConstants(
+                render_cmd, pipeline.gfxLayout,
+                VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT, 0,
+                sizeof(RenderPushConstant), &push_const);
+
+            assert(batch_idx < frame_state.batchFBOffsets.size());
+            glm::u32vec2 batch_offset = frame_state.batchFBOffsets[batch_idx];
+
+            VkViewport viewport;
+            viewport.x = batch_offset.x;
+            viewport.y = batch_offset.y;
+            viewport.width = render_size_.x;
+            viewport.height = render_size_.y;
+            viewport.minDepth = 0.f;
+            viewport.maxDepth = 1.f;
+
+            dev.dt.cmdSetViewport(render_cmd, 0, 1, &viewport);
+
+            for (uint32_t mesh_idx = 0; mesh_idx < scene.meshes.size();
+                 mesh_idx++) {
+                uint32_t num_instances = env.transforms_[mesh_idx].size();
+                if (num_instances == 0) continue;
+
+                auto& mesh = scene.meshes[mesh_idx];
+
+                dev.dt.cmdDrawIndexed(render_cmd, mesh.numIndices,
+                                      num_instances, mesh.startIndex,
+                                      mesh.vertexOffset,
+                                      mesh_instance_offsets[mesh_idx]);
+            }
+
+            ++batch_idx;
         }
     }
 
     dev.dt.cmdEndRenderPass(render_cmd);
 
+    impl::recordFBToLinearCopy(render_cmd, dev, frame_state, fb_cfg_, fb_,
+                               batch_idx);
+
     REQ_VK(dev.dt.endCommandBuffer(render_cmd));
 
     assert(cur_instance < VulkanConfig::max_instances);
 
-    // FIXME 
+    // FIXME
     per_render_buffer_.flush(dev);
 
     uint32_t rendered_frame_idx = cur_frame_;
 
-    submit_func(rendered_frame_idx,
-                frame_state.commands.size(),
-                frame_state.commands.data(),
-                frame_state.fence);
+    submit_func(rendered_frame_idx, frame_state.commands.size(),
+                frame_state.commands.data(), frame_state.fence);
 
     cur_frame_ = (cur_frame_ + 1) % frame_states_.size();
 
     return rendered_frame_idx;
 }
 
-}
+}  // namespace v4r
 
 #endif


### PR DESCRIPTION
Add native support for multi-agent rendering and the ability to deactivate some of the camera views.

Fixed a bug with the phong shader where lighting was only using the specs for the last env.
Fixed a bug where the CPU side results buffer didn't have the correct flags (I don't think this mattered for perf, but it made the validator fail).

I ran clang-format on this with Brennan's settings, but it looks like that wasn't run in a while so there are a lot of formatting changes :/